### PR TITLE
Make running all tests in all package return results

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "pnpm -r lint",
     "lint:ci": "pnpm -r lint:ci",
     "lint:fix": "pnpm -r lint:fix",
-    "test": "pnpm -r test",
+    "test": "pnpm -r test -- --run",
     "test:coverage": "pnpm -r test:coverage",
     "types": "pnpm -r types"
   },


### PR DESCRIPTION
As watch mode is not what we want for all package runs (and does not seem to work in any case).