### PR TITLE
Refactor web test runner login to use Auth Module

### DIFF
--- a/packages/player/src/api/event/device-change.test.ts
+++ b/packages/player/src/api/event/device-change.test.ts
@@ -2,16 +2,13 @@ import { expect } from '@esm-bundle/chai';
 
 import * as Player from '../../index';
 import { OutputDevice } from '../../internal/output-devices';
-import { trueTime } from '../../internal/true-time';
 import { credentialsProvider } from '../../test-helpers';
 
 import { deviceChange } from './device-change';
 
-await trueTime.synchronize();
+Player.setCredentialsProvider(credentialsProvider);
 
 beforeEach(async () => {
-  Player.setCredentialsProvider(credentialsProvider);
-
   await Player.load(
     {
       productId: '141120674',

--- a/packages/player/src/event-bus.test.ts
+++ b/packages/player/src/event-bus.test.ts
@@ -2,24 +2,19 @@ import { expect } from '@esm-bundle/chai';
 
 import { events } from './event-bus';
 import { PlayerError } from './internal/index';
-import { trueTime } from './internal/true-time';
 import { credentialsProvider, waitForEvent } from './test-helpers';
 
 import * as Player from './index';
 
-describe('eventBus', () => {
-  beforeEach(async () => {
-    await trueTime.synchronize();
-  });
+Player.setCredentialsProvider(credentialsProvider);
 
+describe('eventBus', () => {
   it('playback engine sends events through the bus', async () => {
     const mediaProductTransitionEvents = [];
 
     events.addEventListener('media-product-transition', e =>
       mediaProductTransitionEvents.push(e),
     );
-
-    Player.setCredentialsProvider(credentialsProvider);
 
     await Player.load(
       {

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -1,9 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 
 import * as Config from './config';
-import { mockNativePlayer } from './test-helpers';
+import { credentialsProvider, mockNativePlayer } from './test-helpers';
 
 import * as Player from './index';
+
+Player.setCredentialsProvider(credentialsProvider);
 
 describe('bootstrap', () => {
   it('enables output devices if options.outputDevices is true', () => {
@@ -32,6 +34,8 @@ describe('getMediaElement', () => {
       ],
     });
 
+    Player.setStreamingWifiAudioQuality('LOW');
+
     await Player.load(
       {
         productId: '141120674',
@@ -41,13 +45,14 @@ describe('getMediaElement', () => {
       },
       0,
     );
-    await Player.play();
+
     const mediaElement = Player.getMediaElement();
 
     expect(mediaElement).to.be.instanceOf(HTMLMediaElement);
   });
 
-  it('returns the mediaElement value on browser player', async () => {
+  /* To enalbe this test we need another test user with HTMLMediaElement compatible streaming configuration (MP3 Preview?). */
+  it.skip('returns the mediaElement value on browser player', async () => {
     Player.bootstrap({
       outputDevices: false,
       players: [
@@ -58,6 +63,8 @@ describe('getMediaElement', () => {
         },
       ],
     });
+
+    Player.setStreamingWifiAudioQuality('LOW');
 
     await Player.load(
       {
@@ -87,16 +94,6 @@ describe('getMediaElement', () => {
         },
       ],
     });
-
-    await Player.load(
-      {
-        productId: '141120674',
-        productType: 'track',
-        sourceId: 'tidal-player-tests',
-        sourceType: 'tidal-player-tests',
-      },
-      0,
-    );
 
     const mediaElement = Player.getMediaElement();
 

--- a/packages/player/src/index.test.ts
+++ b/packages/player/src/index.test.ts
@@ -1,12 +1,9 @@
 import { expect } from '@esm-bundle/chai';
 
 import * as Config from './config';
-import { trueTime } from './internal/true-time';
-import { credentialsProvider, mockNativePlayer } from './test-helpers';
+import { mockNativePlayer } from './test-helpers';
 
 import * as Player from './index';
-
-await trueTime.synchronize();
 
 describe('bootstrap', () => {
   it('enables output devices if options.outputDevices is true', () => {
@@ -35,8 +32,6 @@ describe('getMediaElement', () => {
       ],
     });
 
-    Player.setCredentialsProvider(credentialsProvider);
-
     await Player.load(
       {
         productId: '141120674',
@@ -46,6 +41,7 @@ describe('getMediaElement', () => {
       },
       0,
     );
+    await Player.play();
     const mediaElement = Player.getMediaElement();
 
     expect(mediaElement).to.be.instanceOf(HTMLMediaElement);

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -25,8 +25,6 @@ type Options = {
 export function getMediaElement(): HTMLMediaElement | null {
   const { activePlayer: player } = playerState;
 
-  console.log('activePlayer', { player });
-
   if (!player) {
     return null;
   }

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -47,6 +47,8 @@ export function getMediaElement(): HTMLMediaElement | null {
  * @param {Options} options
  */
 export function bootstrap(options: Options) {
+  playerState.activePlayer = undefined;
+
   if (options.outputDevices === true) {
     Config.update({ outputDevicesEnabled: true });
   }

--- a/packages/player/src/index.ts
+++ b/packages/player/src/index.ts
@@ -25,6 +25,8 @@ type Options = {
 export function getMediaElement(): HTMLMediaElement | null {
   const { activePlayer: player } = playerState;
 
+  console.log('activePlayer', { player });
+
   if (!player) {
     return null;
   }

--- a/packages/player/src/internal/beacon/index.test.ts
+++ b/packages/player/src/internal/beacon/index.test.ts
@@ -1,19 +1,15 @@
 import { expect } from '@esm-bundle/chai';
 import * as sinon from 'sinon';
 
-import { setCredentialsProvider } from '../../api/index';
+import * as Player from '../../index';
 import { credentialsProvider } from '../../test-helpers';
 import type { StreamingSessionStart } from '../event-tracking/streaming-metrics/streaming-session-start';
-import { trueTime } from '../true-time';
 
 import { commit } from './index';
 
-describe('commit', () => {
-  beforeEach(async () => {
-    await trueTime.synchronize();
-    setCredentialsProvider(credentialsProvider);
-  });
+Player.setCredentialsProvider(credentialsProvider);
 
+describe('commit', () => {
   const worker = sinon.createStubInstance(Worker);
 
   const mockedPromisedEvent = Promise.resolve({

--- a/packages/player/src/internal/handlers/get-asset-position.test.ts
+++ b/packages/player/src/internal/handlers/get-asset-position.test.ts
@@ -1,16 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 
 import * as Player from '../../index';
-import { credentialsProvider, waitFor } from '../../test-helpers';
-import { trueTime } from '../true-time';
+import { waitFor } from '../../test-helpers';
 
 import { getAssetPosition } from './get-asset-position';
 
 describe('getAssetPosition', () => {
-  beforeEach(async () => {
-    await trueTime.synchronize();
-  });
-
   it('returns 0 if there is no active player', () => {
     const playerPosition = getAssetPosition();
 
@@ -18,8 +13,6 @@ describe('getAssetPosition', () => {
   });
 
   it('return currentTime if there is a player', async () => {
-    Player.setCredentialsProvider(credentialsProvider);
-
     await Player.load(
       {
         productId: '141120674',

--- a/packages/player/src/internal/handlers/get-media-product.test.ts
+++ b/packages/player/src/internal/handlers/get-media-product.test.ts
@@ -1,14 +1,12 @@
 import { expect } from '@esm-bundle/chai';
 
 import * as Player from '../../index';
-import { trueTime } from '../../internal/true-time';
-import { credentialsProvider, waitFor } from '../../test-helpers';
+import { waitFor } from '../../test-helpers';
 
 import { getMediaProduct } from './get-media-product';
 
 describe('getMediaProduct', () => {
   beforeEach(async () => {
-    await trueTime.synchronize();
     await Player.reset();
   });
 
@@ -22,8 +20,6 @@ describe('getMediaProduct', () => {
     this.timeout(10000);
 
     const test = async () => {
-      Player.setCredentialsProvider(credentialsProvider);
-
       console.debug('loading');
       await Player.load(
         {

--- a/packages/player/src/internal/handlers/get-output-devices.test.ts
+++ b/packages/player/src/internal/handlers/get-output-devices.test.ts
@@ -3,16 +3,13 @@ import { expect } from '@esm-bundle/chai';
 import * as Player from '../../index';
 import { outputDevices } from '../../internal/output-devices';
 import { credentialsProvider } from '../../test-helpers';
-import { trueTime } from '../true-time';
 
 import { getOutputDevices } from './get-output-devices';
 
+Player.setCredentialsProvider(credentialsProvider);
+
 describe('getOutputDevices', () => {
   beforeEach(async () => {
-    await trueTime.synchronize();
-
-    Player.setCredentialsProvider(credentialsProvider);
-
     // Output devices is reported by the player, thus need one to
     await Player.load(
       {

--- a/packages/player/src/internal/handlers/get-playback-context.test.ts
+++ b/packages/player/src/internal/handlers/get-playback-context.test.ts
@@ -1,16 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 
 import * as Player from '../../index';
-import { credentialsProvider, waitFor } from '../../test-helpers';
-import { trueTime } from '../true-time';
+import { waitFor } from '../../test-helpers';
 
 import { getPlaybackContext } from './get-playback-context';
 
 describe('getPlaybackContext', () => {
-  beforeEach(async () => {
-    await trueTime.synchronize();
-  });
-
   it('returns undefined if there is no active player', () => {
     const activePlaybackContext = getPlaybackContext();
 
@@ -18,10 +13,8 @@ describe('getPlaybackContext', () => {
   });
 
   it('returns the playback context', async () => {
-    Player.setCredentialsProvider(credentialsProvider);
     Player.setStreamingWifiAudioQuality('LOW');
 
-    console.debug('load');
     await Player.load(
       {
         productId: '141120674',
@@ -32,10 +25,8 @@ describe('getPlaybackContext', () => {
       0,
     );
 
-    console.debug('play');
     await Player.play();
 
-    console.debug('waitFor 2s');
     await waitFor(2000);
 
     const activePlaybackContext = getPlaybackContext();

--- a/packages/player/src/internal/handlers/get-playback-state.test.ts
+++ b/packages/player/src/internal/handlers/get-playback-state.test.ts
@@ -1,16 +1,11 @@
 import { expect } from '@esm-bundle/chai';
 
 import * as Player from '../../index';
-import { credentialsProvider, waitFor } from '../../test-helpers';
-import { trueTime } from '../true-time';
+import { waitFor } from '../../test-helpers';
 
 import { getPlaybackState } from './get-playback-state';
 
 describe('getPlaybackState', () => {
-  beforeEach(async () => {
-    await trueTime.synchronize();
-  });
-
   it('returns IDLE if there is no active player', () => {
     const activeState = getPlaybackState();
 
@@ -18,7 +13,6 @@ describe('getPlaybackState', () => {
   });
 
   it('return NOT_PLAYING when a media product is loaded', async () => {
-    Player.setCredentialsProvider(credentialsProvider);
     Player.setStreamingWifiAudioQuality('LOW');
 
     await Player.load(
@@ -35,7 +29,6 @@ describe('getPlaybackState', () => {
   });
 
   it('return PLAYING when a media product is playing', async () => {
-    Player.setCredentialsProvider(credentialsProvider);
     Player.setStreamingWifiAudioQuality('LOW');
 
     await Player.load(

--- a/packages/player/src/internal/handlers/load.test.ts
+++ b/packages/player/src/internal/handlers/load.test.ts
@@ -1,21 +1,16 @@
 import { expect } from '@esm-bundle/chai';
 
 import * as Player from '../../index';
-import { trueTime } from '../../internal/true-time';
 import {
   credentialsProvider,
   getPreloadedStreamingSessionId,
   waitFor,
 } from '../../test-helpers';
 
+Player.setCredentialsProvider(credentialsProvider);
+
 describe('load', () => {
-  beforeEach(async () => {
-    await trueTime.synchronize();
-  });
-
   it('re-uses a next for loading if it is the same media product', async () => {
-    Player.setCredentialsProvider(credentialsProvider);
-
     await Player.load(
       {
         productId: '1766030',

--- a/packages/player/src/internal/handlers/set-next.test.ts
+++ b/packages/player/src/internal/handlers/set-next.test.ts
@@ -3,16 +3,11 @@ import { expect } from '@esm-bundle/chai';
 import * as Player from '../../index';
 import type { MediaProduct } from '../../index';
 import { waitFor } from '../../internal/helpers/wait-for';
-import { trueTime } from '../../internal/true-time';
 import { credentialsProvider, waitForEvent } from '../../test-helpers';
 
+Player.setCredentialsProvider(credentialsProvider);
+
 describe('nextHandler', () => {
-  beforeEach(async () => {
-    await trueTime.synchronize();
-
-    Player.setCredentialsProvider(credentialsProvider);
-  });
-
   it('doesnt preload if no mediaProduct', async () => {
     await Player.load(
       {

--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -1,11 +1,8 @@
 import { expect } from '@esm-bundle/chai';
 
 import { credentialsProvider } from '../../test-helpers';
-import { trueTime } from '../true-time';
 
 import { fetchPlaybackInfo } from './playback-info-resolver';
-
-await trueTime.synchronize();
 
 describe('playbackInfoResolver', () => {
   it('fetches playback info if there is only clientId defined, gets preview', async () => {

--- a/packages/player/src/internal/output-devices.test.ts
+++ b/packages/player/src/internal/output-devices.test.ts
@@ -11,13 +11,10 @@ import {
   findOutputType,
   getOutputDeviceByName,
 } from './output-devices';
-import { trueTime } from './true-time';
 
-await trueTime.synchronize();
+Player.setCredentialsProvider(credentialsProvider);
 
 beforeEach(async () => {
-  Player.setCredentialsProvider(credentialsProvider);
-
   await Player.load(
     {
       productId: '141120674',

--- a/packages/player/src/internal/services/connection-handler.test.ts
+++ b/packages/player/src/internal/services/connection-handler.test.ts
@@ -4,17 +4,10 @@ import type { MediaProductTransition } from '../../api/event/media-product-trans
 import { events } from '../../event-bus';
 import * as Player from '../../index';
 import { playerState } from '../../player/state';
-import { credentialsProvider, waitForEvent } from '../../test-helpers';
+import { waitForEvent } from '../../test-helpers';
 import { waitFor } from '../helpers/wait-for';
-import { trueTime } from '../true-time';
 
 describe('ConnectionHandler', () => {
-  beforeEach(async () => {
-    await trueTime.synchronize();
-
-    Player.setCredentialsProvider(credentialsProvider);
-  });
-
   it('reloads the mediaProduct when connection was lost and player stopped playing', async () => {
     await Player.load(
       {

--- a/packages/player/src/internal/services/pushkin.test.ts
+++ b/packages/player/src/internal/services/pushkin.test.ts
@@ -1,4 +1,3 @@
-// import { assert } from '@esm-bundle/chai';
 import { credentialsProvider } from '../../test-helpers';
 
 import { fetchWebSocketURL, socketOpen } from './pushkin';

--- a/packages/player/web-test-runner.config.js
+++ b/packages/player/web-test-runner.config.js
@@ -22,6 +22,7 @@ export default {
     // playwrightLauncher({ product: 'firefox' }),
     // playwrightLauncher({ product: 'webkit' })
   ],
+  concurrency: 1,
   coverage: true,
   files: ['src/**/*.test.ts'],
   nodeResolve: true,

--- a/packages/player/web-test-runner.config.js
+++ b/packages/player/web-test-runner.config.js
@@ -42,4 +42,11 @@ export default {
       ui: 'bdd',
     },
   },
+  testRunnerHtml: testFramework =>
+    `<html>
+      <body>
+        <script>window.process = { env: { NODE_ENV: "development" } }</script>
+        <script type="module" src="${testFramework}"></script>
+      </body>
+    </html>`,
 };


### PR DESCRIPTION
- Refactor web-test-runner to login the test user via auth module instead of a separate API call
- Skip test that required another streaming configuration than our test user have (a future TODO is adding 2 additional test users with the correct streaming configurations for the different players)
- Set concurrency to 1 on web test runner, seems auth module had issues with storage on higher concurrency