### PR TITLE
Refactor ShakaPlayer initialization

### DIFF
--- a/packages/player/src/player/shakaPlayer.ts
+++ b/packages/player/src/player/shakaPlayer.ts
@@ -357,7 +357,9 @@ export default class ShakaPlayer extends BasePlayer {
   async #createShakaPlayer(mediaEl: HTMLMediaElement) {
     this.debugLog('createShakaPlayer', mediaEl);
 
-    const player = new shaka.Player(mediaEl);
+    const player = new shaka.Player();
+
+    await player.attach(mediaEl);
 
     registerStalls(mediaEl);
     registerAdaptations(player);


### PR DESCRIPTION
Refactor ShakaPlayer initialization from providing the media element in the constructor to calling the attach method. 

Resolves #38