### PR TITLE
make vitest run concurrent by default.

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -29,9 +29,9 @@
     "lint:fix": "pnpm run lint --fix",
     "prepare": "vite build",
     "preview": "vite preview",
-    "test": "vitest",
-    "test:coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui --coverage",
+    "test": "vitest --sequence.concurrent",
+    "test:coverage": "pnpm run test --coverage",
+    "test:ui": "pnpm run test:coverage --ui",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/packages/auth/src/auth/auth.test.ts
+++ b/packages/auth/src/auth/auth.test.ts
@@ -49,7 +49,7 @@ const prepareFetchMock = {
   url: 'https://foo.baz',
 };
 
-describe('auth', () => {
+describe.sequential('auth', () => {
   beforeEach(() => {
     vi.stubGlobal(
       'CustomEvent',

--- a/packages/auth/src/storage/storage.test.ts
+++ b/packages/auth/src/storage/storage.test.ts
@@ -22,7 +22,7 @@ vi.mock('./database', () => ({
   },
 }));
 
-describe('storage', () => {
+describe.sequential('storage', () => {
   beforeEach(() => {
     vi.stubGlobal('crypto', {
       getRandomValues: vi.fn(),

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -29,9 +29,9 @@
     "lint:ci": "eslint . --quiet",
     "lint:fix": "pnpm run lint --fix",
     "preview": "vite preview",
-    "test": "vitest",
-    "test:coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui --coverage",
+    "test": "vitest --sequence.concurrent",
+    "test:coverage": "pnpm run test --coverage",
+    "test:ui": "pnpm run test:coverage --ui",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/packages/event-producer/package.json
+++ b/packages/event-producer/package.json
@@ -29,9 +29,9 @@
     "lint:ci": "eslint . --quiet",
     "lint:fix": "pnpm run lint --fix",
     "preview": "vite preview",
-    "test": "vitest",
-    "test:coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui --coverage",
+    "test": "vitest --sequence.concurrent",
+    "test:coverage": "pnpm run test --coverage",
+    "test:ui": "pnpm run test:coverage --ui",
     "typecheck": "tsc"
   },
   "devDependencies": {

--- a/packages/event-producer/src/dispatch/dispatch.test.ts
+++ b/packages/event-producer/src/dispatch/dispatch.test.ts
@@ -15,7 +15,7 @@ vi.mock('@tidal-music/true-time', () => ({
   trueTime: { now: vi.fn(() => 1337) },
 }));
 
-describe('dispatchEvent', () => {
+describe.sequential('dispatchEvent', () => {
   beforeEach(async () => {
     await uuid.init();
   });

--- a/packages/event-producer/src/monitor/monitor.test.ts
+++ b/packages/event-producer/src/monitor/monitor.test.ts
@@ -7,7 +7,7 @@ import * as sqsParamsConverter from '../utils/sqsParamsConverter';
 
 import * as monitor from './';
 
-describe('monitor', () => {
+describe.sequential('monitor', () => {
   beforeEach(() => {
     init(config);
     monitor.resetMonitoringState();

--- a/packages/event-producer/src/queue/queue.test.ts
+++ b/packages/event-producer/src/queue/queue.test.ts
@@ -17,7 +17,7 @@ vi.mock('./db', () => ({
   },
 }));
 
-describe('Queue', () => {
+describe.sequential('Queue', () => {
   beforeAll(async () => {
     await initUuid();
   });

--- a/packages/event-producer/src/scheduler/scheduler.test.ts
+++ b/packages/event-producer/src/scheduler/scheduler.test.ts
@@ -8,7 +8,7 @@ import * as submit from '../submit/submit';
 import * as scheduler from './scheduler';
 
 vi.useFakeTimers();
-describe('Scheduler', () => {
+describe.sequential('Scheduler', () => {
   beforeEach(() => {
     initConfig(config);
     vi.stubGlobal('console', { error: vi.fn() });

--- a/packages/event-producer/src/submit/submit.test.ts
+++ b/packages/event-producer/src/submit/submit.test.ts
@@ -12,7 +12,7 @@ import { submitEvents } from './submit';
 vi.mock('../queue');
 vi.mock('../monitor');
 
-describe('submit', () => {
+describe.sequential('submit', () => {
   beforeEach(() => {
     vi.mocked(queue).getEvents.mockReturnValue([]);
     vi.mocked(queue).getEventBatch.mockReturnValue([]);

--- a/packages/event-producer/src/uuid/uuid.test.ts
+++ b/packages/event-producer/src/uuid/uuid.test.ts
@@ -5,7 +5,7 @@ vi.mock('nanoid', () => ({
 }));
 const nanoid = vi.mocked(_nanoid);
 
-describe('uuid', () => {
+describe.sequential('uuid', () => {
   beforeEach(() => {
     nanoid.mockReturnValue('aRandomIdFromNanoid');
     // need to reset imports since there are scoped variables in the import for the lazy fallback

--- a/packages/player-web-components/package.json
+++ b/packages/player-web-components/package.json
@@ -33,9 +33,9 @@
     "lint:ci": "eslint . --quiet",
     "lint:fix": "pnpm run lint --fix",
     "preview": "vite preview",
-    "test": "vitest",
-    "test:coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui --coverage",
+    "test": "vitest --sequence.concurrent",
+    "test:coverage": "pnpm run test --coverage",
+    "test:ui": "pnpm run test:coverage --ui",
     "typecheck": "tsc",
     "prepublishOnly": "npx --yes @skypack/package-check --cwd ."
   },

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -30,9 +30,9 @@
     "lint:ci": "eslint . --quiet",
     "lint:fix": "pnpm run lint --fix",
     "preview": "vite preview",
-    "test": "vitest",
-    "test:coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui --coverage",
+    "test": "vitest --sequence.concurrent",
+    "test:coverage": "pnpm run test --coverage",
+    "test:ui": "pnpm run test:coverage --ui",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/packages/true-time/package.json
+++ b/packages/true-time/package.json
@@ -13,8 +13,8 @@
     "lint:ci": "eslint . --quiet",
     "lint:fix": "pnpm run lint --fix",
     "preview": "vite preview",
-    "test": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test": "vitest --sequence.concurrent",
+    "test:coverage": "pnpm run test --coverage"
   },
   "dependencies": {
     "@tidal-music/true-time": "workspace:*"


### PR DESCRIPTION
- Switch vitest to run concurrently by default.
- Had to make some tests with timing or reused mock resources sequential.