### PR TITLE
We decide to make scopes optional to pass to `init`

### DIFF
--- a/packages/auth/examples/client-credentials.js
+++ b/packages/auth/examples/client-credentials.js
@@ -37,7 +37,6 @@ window.addEventListener('load', () => {
       clientId,
       clientSecret,
       credentialsStorageKey: 'clientCredentials',
-      scopes: [],
     });
 
     // hide form to signal "logged in state", display search

--- a/packages/auth/examples/login-redirect.js
+++ b/packages/auth/examples/login-redirect.js
@@ -35,7 +35,6 @@ const submitHandler = async event => {
     clientId,
     clientUniqueKey: 'test',
     credentialsStorageKey: 'loginRedirect',
-    scopes: [],
   });
 
   const loginUrl = await initializeLogin({
@@ -57,7 +56,6 @@ const loadHandler = async () => {
       clientId,
       clientUniqueKey: 'test',
       credentialsStorageKey: 'loginRedirect',
-      scopes: [],
     });
 
     if (window.location.search.length > 0) {

--- a/packages/auth/src/auth/auth.test.ts
+++ b/packages/auth/src/auth/auth.test.ts
@@ -141,6 +141,30 @@ describe.sequential('auth', () => {
         tidalLoginServiceBaseUri: 'https://baz.bar',
       });
     });
+
+    it('inits the auth module with empty scopes', async () => {
+      const trueTimeSpy = vi.spyOn(trueTime, 'synchronize').mockResolvedValue();
+      vi.mocked(storage.loadCredentials).mockResolvedValue(undefined);
+
+      const config = {
+        clientId: 'CLIENT_ID',
+        clientUniqueKey: 'CLIENT_UNIQUE_KEY',
+        credentialsStorageKey: 'CREDENTIALS_STORAGE_KEY',
+      };
+
+      await init(config);
+
+      expect(storage.loadCredentials).toHaveBeenCalledWith(
+        'CREDENTIALS_STORAGE_KEY',
+      );
+      expect(storage.saveCredentialsToStorage).toHaveBeenCalledWith({
+        ...config,
+        scopes: [],
+        tidalAuthServiceBaseUri: 'https://auth.tidal.com/v1/',
+        tidalLoginServiceBaseUri: 'https://login.tidal.com/',
+      });
+      expect(trueTimeSpy).toHaveBeenCalled();
+    });
   });
 
   describe('initializeLogin', () => {

--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -99,7 +99,7 @@ export const init = async ({
     }),
     clientUniqueKey,
     credentialsStorageKey,
-    scopes,
+    scopes: scopes ?? [],
     tidalAuthServiceBaseUri:
       tidalAuthServiceBaseUri ??
       persistedUser?.tidalAuthServiceBaseUri ??

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -5,7 +5,7 @@ export type InitArgs = {
   clientSecret?: string;
   clientUniqueKey?: string;
   credentialsStorageKey: string;
-  scopes: Array<string>;
+  scopes?: Array<string>;
   tidalAuthServiceBaseUri?: string;
   tidalLoginServiceBaseUri?: string;
 };
@@ -16,9 +16,13 @@ export type UserCredentials = {
   expiresIn?: number;
   redirectUri?: string;
   refreshToken?: string;
+  scopes: Array<string>;
   tidalAuthServiceBaseUri: string;
   tidalLoginServiceBaseUri: string;
-} & Omit<InitArgs, 'tidalAuthServiceBaseUri' | 'tidalLoginServiceBaseUri'>;
+} & Omit<
+  InitArgs,
+  'scopes' | 'tidalAuthServiceBaseUri' | 'tidalLoginServiceBaseUri'
+>;
 
 export type SocialNetwork = 'APPLE' | 'FACEBOOK' | 'TWITTER';
 


### PR DESCRIPTION
To make the config even simpler we removed the required `scopes` param. If not supplied we will use an empty array internally.