### PR TITLE
Refactor TrueTime class to improve synchronization logic

### DIFF
--- a/packages/true-time/src/index.ts
+++ b/packages/true-time/src/index.ts
@@ -3,7 +3,7 @@ export class TrueTime {
 
   #serverTime?: number;
 
-  #synced = false;
+  #synced: number | undefined;
 
   #url: URL;
 
@@ -11,7 +11,6 @@ export class TrueTime {
     this.#url = new URL(url);
     this.#clientStartTime = performance.now();
   }
-
   now(highResTimeStamp: DOMHighResTimeStamp = performance.now()): number {
     if (!this.#serverTime || !this.#clientStartTime) {
       throw new ReferenceError(
@@ -33,7 +32,9 @@ export class TrueTime {
    * @param url - server url
    */
   async synchronize() {
-    if (this.#synced) {
+    // Synchronize at max once every 1 000 000 miliseconds
+    // eslint-disable-next-line no-restricted-syntax
+    if (this.#synced && Math.abs(this.#synced - Date.now()) < 1_000_000) {
       return;
     }
 
@@ -42,7 +43,8 @@ export class TrueTime {
 
       if (response.ok && response.headers.has('date')) {
         this.#serverTime = new Date(response.headers.get('date')!).getTime();
-        this.#synced = true;
+        // eslint-disable-next-line no-restricted-syntax
+        this.#synced = Date.now();
       }
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
Long over-night or over-weekend sessions could get wrong timestamps.

This pull request includes changes to the `TrueTime` class in the `packages/true-time/src/index.ts` file. The changes are focused on modifying the `#synced` private member and its usage in the `synchronize` method to ensure the synchronization process doesn't occur more frequently than once every 1,000,000 milliseconds. 

* [`packages/true-time/src/index.ts`](diffhunk://#diff-82b570184b3023585c1141387bba4e89ebeebb22f7c9c4024b78f4ba161778a9L6-L14): The `#synced` private member was modified from a boolean to a number or undefined. This change allows the storage of the timestamp of the last successful synchronization.
* [`packages/true-time/src/index.ts`](diffhunk://#diff-82b570184b3023585c1141387bba4e89ebeebb22f7c9c4024b78f4ba161778a9L36-R37): In the `synchronize` method, a check was added to ensure that synchronization doesn't occur if the last successful synchronization was less than 1,000,000 milliseconds ago.
* [`packages/true-time/src/index.ts`](diffhunk://#diff-82b570184b3023585c1141387bba4e89ebeebb22f7c9c4024b78f4ba161778a9L45-R47): The `#synced` private member is now set to the current timestamp (`Date.now()`) after a successful synchronization.