### PR TITLE
To be more consistent we added the clientSecret in all requests to backend

### DIFF
--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -179,6 +179,9 @@ export const initializeDeviceLogin = async () => {
 
   const body = {
     client_id: state.credentials.clientId,
+    ...(state.credentials.clientSecret && {
+      client_secret: state.credentials.clientSecret,
+    }),
     scope: state.credentials.scopes.join(' '),
   };
 
@@ -225,8 +228,14 @@ export const finalizeLogin = async (loginResponseQuery: string) => {
     throw new TidalError(authErrorCodeMap.initError);
   }
 
-  const { clientId, clientUniqueKey, codeChallenge, redirectUri, scopes } =
-    state.credentials;
+  const {
+    clientId,
+    clientSecret,
+    clientUniqueKey,
+    codeChallenge,
+    redirectUri,
+    scopes,
+  } = state.credentials;
 
   const params = Object.fromEntries(new URLSearchParams(loginResponseQuery));
 
@@ -237,6 +246,9 @@ export const finalizeLogin = async (loginResponseQuery: string) => {
   const body = {
     client_id: clientId,
     client_unique_key: clientUniqueKey ?? '',
+    ...(clientSecret && {
+      client_secret: clientSecret,
+    }),
     code: params.code,
     code_verifier: codeChallenge,
     grant_type: 'authorization_code',
@@ -361,6 +373,9 @@ export const logout = () => {
 const refreshAccessToken = async () => {
   if (state.credentials?.refreshToken) {
     const body = {
+      ...(state.credentials.clientSecret && {
+        client_secret: state.credentials.clientSecret,
+      }),
       client_id: state.credentials.clientId,
       grant_type: 'refresh_token',
       refresh_token: state.credentials.refreshToken,
@@ -388,6 +403,9 @@ const refreshAccessToken = async () => {
 const upgradeToken = async () => {
   if (state.credentials?.refreshToken) {
     const body = {
+      ...(state.credentials.clientSecret && {
+        client_secret: state.credentials.clientSecret,
+      }),
       client_id: state.credentials.clientId,
       grant_type: 'update_client',
       refresh_token: state.credentials.refreshToken,

--- a/packages/auth/src/fixtures.ts
+++ b/packages/auth/src/fixtures.ts
@@ -9,6 +9,7 @@ export const storage = {
     userId: '123456789',
   },
   clientId: 'CLIENT_ID',
+  clientSecret: 'CLIENT_SECRET',
   clientUniqueKey: 'CLIENT_UNIQUE_KEY',
   codeChallenge: 'CODE_CHALLENGE',
   credentialsStorageKey: 'CREDENTIALS_STORAGE_KEY',


### PR DESCRIPTION
From now on clientSecret will be sent for all auth methods when provided.
Internal testing is done and code can be reviewed.

Internal Ticket: WIMPWC-10630