### PR TITLE
Fixed an issue with client credentials were token wasn't upgraded properly

### DIFF
--- a/packages/auth/src/fixtures.ts
+++ b/packages/auth/src/fixtures.ts
@@ -13,8 +13,27 @@ export const storage = {
   clientUniqueKey: 'CLIENT_UNIQUE_KEY',
   codeChallenge: 'CODE_CHALLENGE',
   credentialsStorageKey: 'CREDENTIALS_STORAGE_KEY',
+  previousClientSecret: 'CLIENT_SECRET',
   redirectUri: 'https://redirect.uri',
   refreshToken: 'REFRESH_TOKEN',
+  scopes: ['READ', 'WRITE'],
+  tidalAuthServiceBaseUri: 'https://auth.tidal.com/v1/',
+  tidalLoginServiceBaseUri: 'https://login.tidal.com/',
+};
+
+export const storageClientCredentials = {
+  accessToken: {
+    clientId: 'CLIENT_ID',
+    clientUniqueKey: undefined,
+    expires: 1694864347517,
+    grantedScopes: [],
+    requestedScopes: [],
+    token: 'ACCESS_TOKEN',
+  },
+  clientId: 'CLIENT_ID',
+  clientSecret: 'CLIENT_SECRET',
+  credentialsStorageKey: 'CREDENTIALS_STORAGE_KEY',
+  previousClientSecret: 'CLIENT_SECRET',
   scopes: ['READ', 'WRITE'],
   tidalAuthServiceBaseUri: 'https://auth.tidal.com/v1/',
   tidalLoginServiceBaseUri: 'https://login.tidal.com/',
@@ -28,6 +47,13 @@ export const userJsonResponse = {
   scope: 'READ WRITE',
   token_type: 'Bearer' as const,
   user_id: 123456789,
+};
+
+export const clientCredentialsJsonResponse = {
+  access_token: 'ACCESS_TOKEN',
+  expires_in: 12356,
+  scope: '',
+  token_type: 'Bearer' as const,
 };
 
 export const expiresTimerMock =

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,4 @@
+/* c8 ignore start index file */
 import type { CredentialsProvider } from '@tidal-music/common';
 
 import { bus, getCredentials } from './auth/auth';

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -1,3 +1,4 @@
+/* c8 ignore start types file */
 import type { Credentials } from '@tidal-music/common';
 
 export type InitArgs = {

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -14,6 +14,7 @@ export type UserCredentials = {
   accessToken?: Credentials;
   codeChallenge?: string;
   expiresIn?: number;
+  previousClientSecret?: string;
   redirectUri?: string;
   refreshToken?: string;
   scopes: Array<string>;

--- a/packages/auth/vite.config.ts
+++ b/packages/auth/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig(({ command }) => {
     plugins: [dts({ rollupTypes: true, tsconfigPath: 'tsconfig.build.json' })],
     test: {
       coverage: {
+        exclude: ['examples/**'],
         reportOnFailure: true,
         reporter: process.env.CI ? ['json', 'json-summary'] : ['html'],
         thresholds: {

--- a/packages/auth/vite.config.ts
+++ b/packages/auth/vite.config.ts
@@ -37,9 +37,9 @@ export default defineConfig(({ command }) => {
         reporter: process.env.CI ? ['json', 'json-summary'] : ['html'],
         thresholds: {
           branches: 80,
-          functions: 73.77,
-          lines: 69.41,
-          statements: 69.41,
+          functions: 80,
+          lines: 80,
+          statements: 80,
         },
       },
       globals: true,


### PR DESCRIPTION
This was found during testing by @osmestad and led to an update of the spec.
We are now re-requesting (upgrading) tokens also for client credentials when the clientId or clientSecret changes in the init.