### PR TITLE
Convert TrueTime to use Date.now

### DIFF
--- a/packages/player/src/internal/handlers/load.ts
+++ b/packages/player/src/internal/handlers/load.ts
@@ -64,7 +64,10 @@ export async function load(
 
     performance.mark(
       'streaming_metrics:playback_statistics:idealStartTimestamp',
-      { detail: playerState.preloadedStreamingSessionId },
+      {
+        detail: playerState.preloadedStreamingSessionId,
+        startTime: trueTime.now(),
+      },
     );
 
     await player.reset({ keepPreload: true });
@@ -101,7 +104,10 @@ export async function load(
 
   performance.mark(
     'streaming_metrics:playback_statistics:idealStartTimestamp',
-    { detail: streamingSessionId },
+    {
+      detail: streamingSessionId,
+      startTime: trueTime.now(),
+    },
   );
 
   const { clientId, token } =

--- a/packages/player/src/internal/helpers/playback-info-resolver.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.ts
@@ -247,6 +247,7 @@ export async function fetchPlaybackInfo(options: Options) {
 
   performance.mark('streaming_metrics:playback_info_fetch:startTimestamp', {
     detail: streamingSessionId,
+    startTime: trueTime.now(),
   });
 
   try {
@@ -292,12 +293,14 @@ export async function fetchPlaybackInfo(options: Options) {
 
     performance.mark('streaming_metrics:playback_info_fetch:endTimestamp', {
       detail: streamingSessionId,
+      startTime: trueTime.now(),
     });
 
     return playbackInfo;
   } catch (e) {
     performance.mark('streaming_metrics:playback_info_fetch:endTimestamp', {
       detail: streamingSessionId,
+      startTime: trueTime.now(),
     });
 
     StreamingMetrics.playbackInfoFetch({

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -108,6 +108,7 @@ export class BasePlayer {
         'streaming_metrics:playback_statistics:idealStartTimestamp',
         {
           detail: playerState.preloadedStreamingSessionId,
+          startTime: trueTime.now(),
         },
       );
     }
@@ -289,6 +290,7 @@ export class BasePlayer {
       'streaming_metrics:playback_statistics:actualStartTimestamp',
       {
         detail: streamingSessionId,
+        startTime: trueTime.now(),
       },
     );
 

--- a/packages/player/src/player/shakaPlayer.ts
+++ b/packages/player/src/player/shakaPlayer.ts
@@ -420,6 +420,7 @@ export default class ShakaPlayer extends BasePlayer {
 
         performance.mark('streaming_metrics:drm_license_fetch:startTimestamp', {
           detail: streamingSessionId,
+          startTime: trueTime.now(),
         });
 
         const streamInfo =
@@ -444,6 +445,7 @@ export default class ShakaPlayer extends BasePlayer {
         if (this.currentStreamingSessionId) {
           performance.mark('streaming_metrics:drm_license_fetch:endTimestamp', {
             detail: this.currentStreamingSessionId,
+            startTime: trueTime.now(),
           });
 
           performance.measure('streaming_metrics:drm_license_fetch', {

--- a/packages/true-time/src/index.test.ts
+++ b/packages/true-time/src/index.test.ts
@@ -15,13 +15,14 @@ describe('TrueTime', () => {
     describe('now', () => {
       it('returns the Date.now() value adjusted to server time', () => {
         const thirtyDays = 2_592_000_000;
+        const currentTime = Date.now();
 
         vi.setSystemTime(new Date(Date.now() - thirtyDays));
 
         // Assert that TrueTime has adjusted
-        expect(trueTime.now()).not.toEqual(Date.now());
+        expect(trueTime.now(currentTime)).not.toEqual(Date.now());
 
-        const diff = Math.abs(trueTime.now() - Date.now());
+        const diff = Math.abs(trueTime.now(currentTime) - Date.now());
 
         // Check the diff and allow for 100 ms offset due to test timings.
         // Chai style assertion that works, but is unexpected:
@@ -32,7 +33,7 @@ describe('TrueTime', () => {
 
     describe('timestamp', () => {
       test('returns adjusted time at mark', () => {
-        performance.mark('before time travel');
+        performance.mark('before time travel', { startTime: trueTime.now() });
 
         expect(trueTime.timestamp('before time travel')).toBeTypeOf('number');
       });
@@ -42,7 +43,10 @@ describe('TrueTime', () => {
       });
 
       test('returns adjusted time at mark for a scoped mark', () => {
-        performance.mark('time-mark', { detail: 'getmjölk' });
+        performance.mark('time-mark', {
+          detail: 'getmjölk',
+          startTime: trueTime.now(),
+        });
 
         expect(trueTime.timestamp('time-mark', 'getmjölk')).toBeTypeOf(
           'number',
@@ -50,7 +54,10 @@ describe('TrueTime', () => {
       });
 
       test('throw error if an expected mark detail is missing', () => {
-        performance.mark('time-mark', { detail: 'getmjölk' });
+        performance.mark('time-mark', {
+          detail: 'getmjölk',
+          startTime: trueTime.now(),
+        });
 
         expect(() => trueTime.timestamp('time-mark', 'honung')).toThrowError(
           'There is no performance entry named "time-mark" with detail "honung"',
@@ -72,6 +79,8 @@ describe('TrueTime', () => {
 
     describe('timestamp', () => {
       test('throws error due to no synchronize call', async () => {
+        // PS `performance.mark` should not be called without `startTime: trueTime.now()` option,
+        // but doing it here to test the error.
         performance.mark('birds are dinosaurs');
 
         expect(() => trueTime.timestamp('birds are dinosaurs')).toThrowError(

--- a/packages/true-time/src/index.ts
+++ b/packages/true-time/src/index.ts
@@ -29,7 +29,7 @@ export class TrueTime {
 
   /**
    * Synchronizes the client's time with the server's time.
-   * If the client's time is already synchronized within an hour, no action is taken.
+   * If the client's time is already synchronized within an hour, this method does nothing.
    *
    * @returns {Promise<void>} A promise that resolves when the synchronization is complete.
    */

--- a/packages/true-time/src/index.ts
+++ b/packages/true-time/src/index.ts
@@ -3,8 +3,6 @@ export class TrueTime {
 
   #serverTime?: number;
 
-  #synced = false;
-
   #url: URL;
 
   constructor(url: string) {
@@ -31,12 +29,18 @@ export class TrueTime {
 
   /**
    * Synchronizes the client's time with the server's time.
-   * If already synchronized, this method does nothing.
+   * If the client's time is already synchronized within an hour, no action is taken.
    *
    * @returns {Promise<void>} A promise that resolves when the synchronization is complete.
    */
   async synchronize(): Promise<void> {
-    if (this.#synced) {
+    const anHour = 3_600_000;
+
+    if (
+      this.#clientStartTime &&
+      // eslint-disable-next-line no-restricted-syntax
+      Math.abs(Date.now() - this.#clientStartTime) < anHour
+    ) {
       return;
     }
 
@@ -47,7 +51,6 @@ export class TrueTime {
         this.#serverTime = new Date(response.headers.get('date')!).getTime();
         // eslint-disable-next-line no-restricted-syntax
         this.#clientStartTime = Date.now();
-        this.#synced = true;
       }
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
This should be a simpler approach that has less risk of clock drift that can happen with `performance.now()` used over idle time-spans.
Using our `trueTime.now()` when setting performance marks should ensure all timestamps are of the same type/time-scale.