### PR TITLE
Bump auth to release a fresh version

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/auth",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
Several small improvements in auth.
- empty scopes for `init` can be omitted
- credentials are now sent with bus event
- token upgrade for clientCredentials is fixed
- clientSecret will be passed along in all auth flows