### PR TITLE
Tweaks to PNPM publishing

### DIFF
--- a/.github/workflows/release-to-npm.yml
+++ b/.github/workflows/release-to-npm.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - run: pnpm clean
-      - run: pnpm publish --access public
+      - run: pnpm publish --recursive --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
* Needs to disable git-checks (as this is ran from a tag, not from `main`)
* Needs to publish recursively as this is a monorepo and we run the command from root