### PR TITLE
Stop cleaning too much

### DIFF
--- a/.github/workflows/release-to-npm.yml
+++ b/.github/workflows/release-to-npm.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
-      - run: pnpm clean
       - run: pnpm publish --recursive --no-git-checks --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
As it broke publishing of packages with dependencies on other packages in the monorepo (also it should not be needed).