### PR TITLE
Haff/optional filtering out feral events

### DIFF
--- a/packages/event-producer/package.json
+++ b/packages/event-producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/event-producer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/event-producer/src/config.ts
+++ b/packages/event-producer/src/config.ts
@@ -18,6 +18,8 @@ export type Config = {
   credentialsProvider?: CredentialsProvider;
   // frequency of sending events to TL Consumer
   eventBatchInterval?: number;
+  // event types to exclude from persisted memory, ie a malformed event from a previous release
+  feralEventTypes?: Array<string>;
   // frequency of monitoring info sending
   monitoringInterval?: number;
   platform: PlatformData;

--- a/packages/event-producer/src/init.ts
+++ b/packages/event-producer/src/init.ts
@@ -13,6 +13,10 @@ import { init as initUuid } from './uuid/uuid';
  */
 export const init = async (initialConfig: config.Config) => {
   config.init(initialConfig);
-  await Promise.all([trueTime.synchronize(), initUuid(), queue.initDB()]);
+  await Promise.all([
+    trueTime.synchronize(),
+    initUuid(),
+    queue.initDB({ feralEventTypes: initialConfig.feralEventTypes }),
+  ]);
   scheduler.init(config.getConfig());
 };

--- a/packages/event-producer/src/queue/queue.test.ts
+++ b/packages/event-producer/src/queue/queue.test.ts
@@ -1,6 +1,6 @@
 import '@vitest/web-worker';
 
-import { epEvent1 } from '../../test/fixtures/events';
+import { epEvent1, epEvent2 } from '../../test/fixtures/events';
 import { init as initUuid } from '../uuid/uuid';
 
 import { db as _db } from './db';
@@ -48,9 +48,16 @@ describe.sequential('Queue', () => {
       action: 'persist',
       events: [epEvent1],
     });
-    vi.waitFor(() => {
+    await vi.waitFor(() => {
       expect(db.setItem).toHaveBeenCalledWith('events', [epEvent1]);
     });
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+  });
+
+  it('init: filters out designated event types', async () => {
+    db.getItem.mockResolvedValueOnce([epEvent1, epEvent2]);
+
+    await queue.initDB({ feralEventTypes: [epEvent2.name] });
+
+    expect(queue.getEvents()).toEqual([epEvent1]);
   });
 });

--- a/packages/event-producer/src/queue/queue.ts
+++ b/packages/event-producer/src/queue/queue.ts
@@ -55,7 +55,7 @@ export function setEvents(newEvents: Array<EPEvent>) {
  *
  * @returns {Promise<void>}
  */
-export const initDB = (c?: {
+export const initDB = (options?: {
   feralEventTypes: Config['feralEventTypes'];
 }): Promise<void> =>
   new Promise<void>((resolve, reject) => {
@@ -64,7 +64,7 @@ export const initDB = (c?: {
       switch (data.action) {
         case 'initSuccess': {
           if (data.events) {
-            const feralEvents = c?.feralEventTypes ?? [];
+            const feralEvents = options?.feralEventTypes ?? [];
             // remove events in the wild that might be jamming the queue
             const events =
               feralEvents.length > 0

--- a/packages/event-producer/src/queue/queue.ts
+++ b/packages/event-producer/src/queue/queue.ts
@@ -64,12 +64,11 @@ export const initDB = (c?: {
       switch (data.action) {
         case 'initSuccess': {
           if (data.events) {
+            const feralEvents = c?.feralEventTypes ?? [];
             // remove events in the wild that might be jamming the queue
             const events =
-              c?.feralEventTypes && c.feralEventTypes.length > 0
-                ? data.events.filter(
-                    event => !c.feralEventTypes.includes(event.name),
-                  )
+              feralEvents.length > 0
+                ? data.events.filter(event => !feralEvents.includes(event.name))
                 : data.events;
             setEvents(getEvents().concat(events));
           }

--- a/packages/event-producer/test/fixtures/events.ts
+++ b/packages/event-producer/test/fixtures/events.ts
@@ -19,3 +19,10 @@ export const epEvent1: EPEvent = {
   name: 'fakeName',
   payload: JSON.stringify(eventPayload1.payload),
 };
+
+export const epEvent2: EPEvent = {
+  headers: {},
+  id: 'idnr2',
+  name: 'bacon',
+  payload: JSON.stringify(eventPayload1.payload),
+};


### PR DESCRIPTION
We found some instances of bad events in production that jammed the event-queue. This will allow us to filter out those bad bois and unclog the event-producer.