### PR TITLE
Haff/ep dedupe

### DIFF
--- a/packages/event-producer/package.json
+++ b/packages/event-producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/event-producer",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "files": [
     "dist"

--- a/packages/event-producer/src/index.ts
+++ b/packages/event-producer/src/index.ts
@@ -42,26 +42,23 @@ export const init = (config: Config) => _init(config);
 export { bus };
 
 /* c8 ignore start debug only */
-if (import.meta.env.DEV) {
-  // @ts-expect-error dev builds only
-  globalThis.__tepDebug = {
-    bus,
-    dropEvent: () => {
-      monitor.registerDroppedEvent({
-        eventName: 'bacon',
-        reason: 'consentFilteredEvents',
-      });
-    },
-    dumpConfig: () => getConfig(),
-    flushEvents: () =>
-      submitEvents({ config: getConfig() }).catch(console.error),
-    flushMonitoring: monitor.sendMonitoringInfo,
-    getEvents: queue.getEvents,
-    killQueue: async () => {
-      queue.setEvents([]);
-      queue.persistEvents();
-    },
-    setOutage: outage.setOutage,
-  };
-}
+// @ts-expect-error dev builds only
+globalThis.__tepDebug = {
+  bus,
+  dropEvent: () => {
+    monitor.registerDroppedEvent({
+      eventName: 'bacon',
+      reason: 'consentFilteredEvents',
+    });
+  },
+  dumpConfig: () => getConfig(),
+  flushEvents: () => submitEvents({ config: getConfig() }).catch(console.error),
+  flushMonitoring: monitor.sendMonitoringInfo,
+  getEvents: queue.getEvents,
+  killQueue: async () => {
+    queue.setEvents([]);
+    queue.persistEvents();
+  },
+  setOutage: outage.setOutage,
+};
 /* c8 ignore stop */


### PR DESCRIPTION
We're seeing some issues in prod where the queue is loaded with duplicate ids in production. This is just fixing the symptom while i dig deeper into the real issue.