### PR TITLE
Fix for running Vitest in VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "eslint-config-tidal": "3.2.0",
     "eslint-plugin-disable-autofix": "4.3.0",
     "eslint-plugin-jsdoc": "48.2.3",
-    "typedoc": "0.25.13"
+    "typedoc": "0.25.13",
+    "vitest": "1.4.0"
   },
   "engines": {
     "node": ">=20.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       typedoc:
         specifier: 0.25.13
         version: 0.25.13(typescript@5.4.4)
+      vitest:
+        specifier: 1.4.0
+        version: 1.4.0(@vitest/ui@1.4.0)(happy-dom@14.7.1)
 
   packages/auth:
     dependencies:
@@ -3195,7 +3198,7 @@ packages:
   /@vitest/snapshot@1.4.0:
     resolution: {integrity: sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==}
     dependencies:
-      magic-string: 0.30.5
+      magic-string: 0.30.8
       pathe: 1.1.1
       pretty-format: 29.7.0
     dev: true
@@ -8938,7 +8941,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       execa: 8.0.1
       local-pkg: 0.5.0
-      magic-string: 0.30.5
+      magic-string: 0.30.8
       pathe: 1.1.1
       picocolors: 1.0.0
       std-env: 3.6.0
@@ -8995,7 +8998,7 @@ packages:
       execa: 8.0.1
       happy-dom: 14.7.1
       local-pkg: 0.5.0
-      magic-string: 0.30.5
+      magic-string: 0.30.8
       pathe: 1.1.1
       picocolors: 1.0.0
       std-env: 3.6.0

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,1 +1,1 @@
-export default ['packages/**/src/*'];
+export default ['packages/*'];


### PR DESCRIPTION
As current config was not picked up by IDE extension