### PR TITLE
TIP-401: Fix issue with timestamp that broke CDF events

### DIFF
--- a/packages/event-producer/package.json
+++ b/packages/event-producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/event-producer",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "files": [
     "dist"

--- a/packages/event-producer/src/monitor/index.ts
+++ b/packages/event-producer/src/monitor/index.ts
@@ -75,7 +75,7 @@ export const sendMonitoringInfo = async () => {
         consentCategory: 'NECESSARY',
         credentials: await config.credentialsProvider?.getCredentials(),
         platformData: config.platform,
-        sentTimestamp: trueTime.now().toString(),
+        sentTimestamp: trueTime.now(),
       }),
       id: uuid(),
       name: 'tep-tl-monitoring',

--- a/packages/event-producer/src/send/send.test.ts
+++ b/packages/event-producer/src/send/send.test.ts
@@ -33,7 +33,7 @@ describe.sequential('sendEvent', () => {
       expect.objectContaining({
         payload: JSON.stringify({
           ...eventWithoutConsentCategory,
-          ts: '1337',
+          ts: 1337,
           uuid: 'fakeUuid',
         }),
       }),

--- a/packages/event-producer/src/send/send.ts
+++ b/packages/event-producer/src/send/send.ts
@@ -12,7 +12,7 @@ import { uuid } from '../uuid/uuid';
 type CreatePayloadParams = {
   event: SentEvent;
   id: string;
-  ts: string;
+  ts: number;
 };
 /**
  * Creates a payload to be sent to backend. The payload is the whole raw event with uuid
@@ -40,7 +40,7 @@ const createEvent = async ({
   event,
 }: SendEventParams): Promise<EPEvent> => {
   const id = uuid();
-  const sentTimestamp = trueTime.now().toString();
+  const sentTimestamp = trueTime.now();
   const headers = getEventHeaders({
     appInfo: config.appInfo,
     consentCategory: event.consentCategory,

--- a/packages/event-producer/src/types.ts
+++ b/packages/event-producer/src/types.ts
@@ -8,7 +8,7 @@ export type AppInfo = {
   appVersion: string;
 };
 
-export type EventHeaders = Record<string, string>;
+export type EventHeaders = Record<string, number | string>;
 
 /**
  * This is an incoming raw event.

--- a/packages/event-producer/src/utils/headerUtils.test.ts
+++ b/packages/event-producer/src/utils/headerUtils.test.ts
@@ -12,7 +12,7 @@ describe('headerUtils', () => {
       consentCategory: 'NECESSARY',
       credentials: credentials1,
       platformData: config.platform,
-      sentTimestamp: '2023',
+      sentTimestamp: 2023,
       suppliedHeaders: {
         someXtraHeader: 'eggs',
       },
@@ -26,7 +26,7 @@ describe('headerUtils', () => {
       'client-id': 'fakeClientId',
       'consent-category': 'NECESSARY',
       'os-name': config.platform.osName,
-      'requested-sent-timestamp': '2023',
+      'requested-sent-timestamp': 2023,
       someXtraHeader: 'eggs',
     });
   });
@@ -37,7 +37,7 @@ describe('headerUtils', () => {
       consentCategory: 'NECESSARY',
       credentials: credentials1,
       platformData: config.platform,
-      sentTimestamp: '2023',
+      sentTimestamp: 2023,
       suppliedHeaders: {
         'app-name': 'bacon',
         someXtraHeader: 'eggs',

--- a/packages/event-producer/src/utils/headerUtils.ts
+++ b/packages/event-producer/src/utils/headerUtils.ts
@@ -17,8 +17,8 @@ export const getEventHeaders = ({
   consentCategory: ConsentCategory;
   credentials?: Credentials;
   platformData: PlatformData;
-  sentTimestamp: string;
-  suppliedHeaders?: Record<string, string>;
+  sentTimestamp: number;
+  suppliedHeaders?: Record<string, number | string>;
 }) => {
   const accessToken = credentials?.token;
   const clientId = credentials?.clientId ?? 'clientIDMissing!';


### PR DESCRIPTION
Confirmed that several types of events are now coming through when I point my local instance towards prod and check the tables. The error was due to the timestamp being a string.