### PR TITLE
Use standard name for authorization code flow

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -25,7 +25,7 @@ This authentication method uses `clientId` and `clientSecret`, e.g. when utilizi
 ## Authorization Code Flow (user login)
 (Only available for TIDAL internally developed applications for now)
 
-To implement the login redirect flow, follow these steps or refer to our example for ["login redirect"](./examples/login-redirect.html).
+To implement the login redirect flow, follow these steps or refer to our example for ["authorization code"](./examples/authorization-code.html).
 
 1. Initiate the process by calling the `init` function.
 2. For the first login:

--- a/packages/auth/examples/authorization-code.html
+++ b/packages/auth/examples/authorization-code.html
@@ -17,7 +17,7 @@
 
 <body>
   <a href="../">Back to all examples</a>
-  <h1>Login redirect</h1>
+  <h1>Authorization code</h1>
   <p>
     This example showcases how to login through login.tidal.com and get redirected back to your app.
     You need a properly configured clientId, which is tied to a secure redirect uri.
@@ -26,7 +26,7 @@
   </p>
 
 
-  <form id="loginRedirectForm">
+  <form id="authorizationCodeForm">
     <label>
       <span>Client Id</span>
       <input type="text" name="clientId" required />
@@ -45,7 +45,7 @@
   <button id="getUserBtn">Get user</button>
   <button id="forceRefreshBtn">Force Refresh (sub status)</button>
 
-  <script type="module" src="./login-redirect.js"></script>
+  <script type="module" src="./authorization-code.js"></script>
 </body>
 
 </html>

--- a/packages/auth/examples/authorization-code.js
+++ b/packages/auth/examples/authorization-code.js
@@ -3,7 +3,7 @@ import { finalizeLogin, init, initializeLogin, logout } from '../dist';
 import { getUserInfo } from './shared';
 
 window.addEventListener('load', () => {
-  const form = document.getElementById('loginRedirectForm');
+  const form = document.getElementById('authorizationCodeForm');
   const logoutButton = document.getElementById('logoutBtn');
 
   form?.addEventListener('submit', event => {
@@ -34,7 +34,7 @@ const submitHandler = async event => {
   await init({
     clientId,
     clientUniqueKey: 'test',
-    credentialsStorageKey: 'loginRedirect',
+    credentialsStorageKey: 'authorizationCode',
   });
 
   const loginUrl = await initializeLogin({
@@ -47,7 +47,7 @@ const submitHandler = async event => {
 const loadHandler = async () => {
   const clientId = localStorage.getItem('clientId');
   const redirectUri = localStorage.getItem('redirectUri');
-  const form = document.getElementById('loginRedirectForm');
+  const form = document.getElementById('authorizationCodeForm');
 
   if (clientId && redirectUri) {
     form.style.display = 'none';
@@ -55,12 +55,12 @@ const loadHandler = async () => {
     await init({
       clientId,
       clientUniqueKey: 'test',
-      credentialsStorageKey: 'loginRedirect',
+      credentialsStorageKey: 'authorizationCode',
     });
 
     if (window.location.search.length > 0) {
       await finalizeLogin(window.location.search);
-      window.location.replace('/examples/login-redirect.html');
+      window.location.replace('/examples/authorization-code.html');
     } else {
       await getUserInfo();
       document.getElementById('getUserBtn').style.display = 'block';

--- a/packages/auth/index.html
+++ b/packages/auth/index.html
@@ -13,7 +13,7 @@
   <h1>Auth module examples</h1>
   <ul>
     <li><a href="./examples/client-credentials.html">Client Credentials</a></li>
-    <li><a href="./examples/login-redirect.html">Login redirect</a></li>
+    <li><a href="./examples/authorization-code.html">Authorization code</a></li>
     <li><a href="./examples/limited-input-device.html">Limited input device (e.g. TVs)</a></li>
     <li><a href="./examples/setting-credentials.html">Setting credentials</a></li>
   </ul>


### PR DESCRIPTION
We decided to rename the examples for authorization code flow to match the official docs.