### PR TITLE
[Player] Store data without IndexedDB

### DIFF
--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -57,6 +57,7 @@
     "@tidal-music/auth": "workspace:^",
     "@tidal-music/common": "workspace:^",
     "@tidal-music/true-time": "workspace:^",
+    "@types/chai": "4.3.14",
     "@types/js-levenshtein": "1.1.3",
     "@types/mocha": "10.0.6",
     "@types/node": "20.12.7",

--- a/packages/player/src/internal/helpers/event-session.ts
+++ b/packages/player/src/internal/helpers/event-session.ts
@@ -42,8 +42,6 @@ class EventSessionDB {
     );
 
     this.#db.delete(compositeKey);
-    console.debug('[EventSessionDB] delete');
-    console.table(Object.fromEntries(this.#db.entries()));
   }
 
   /**
@@ -60,9 +58,6 @@ class EventSessionDB {
       streamingSessionId,
       name,
     );
-
-    console.debug('[EventSessionDB] get');
-    console.table(Object.fromEntries(this.#db.entries()));
 
     return this.#db.get(compositeKey);
   }
@@ -82,8 +77,6 @@ class EventSessionDB {
     );
 
     this.#db.set(compositeKey, value);
-    console.debug('[EventSessionDB] put');
-    console.table(Object.fromEntries(this.#db.entries()));
   }
 }
 

--- a/packages/player/src/internal/helpers/event-session.ts
+++ b/packages/player/src/internal/helpers/event-session.ts
@@ -7,65 +7,10 @@ type MaybeEvent<P> =
   | undefined;
 
 class EventSessionDB {
-  // @ts-expect-error - Assigned through private method #init.
-  #db: IDBDatabase;
-  // @ts-expect-error - Assigned through private method #init.
-  #name: string;
-  #openingDatabase: Promise<void> | undefined;
+  #db: Map<string, any>;
 
   constructor() {
-    this.#createNewDatabase().catch(console.error);
-  }
-
-  /**
-   * Create a new database and set the #openingDatabase promise to undefined when it's done.
-   */
-  async #createNewDatabase() {
-    this.#openingDatabase = this.#init().then(() => {
-      this.#openingDatabase = undefined;
-    });
-
-    return this.#openingDatabase;
-  }
-
-  /**
-   * Ensure that the database is open and ready to use. Using a promise to
-   * debounce multiple calls to this method.
-   */
-  async #ensureDatabase() {
-    let isExisting = false;
-
-    if (this.#openingDatabase) {
-      await this.#openingDatabase;
-    } else {
-      // Attempt to open the database
-      this.#openingDatabase = new Promise<void>((resolve, reject) => {
-        const request = window.indexedDB.open(this.#name);
-
-        // This event means the database was found and successfully opened
-        request.onsuccess = () => {
-          isExisting = true; // Database exists
-          resolve();
-          request.result.close(); // Close the database connection
-        };
-
-        // This event means the database does not exist and is being created
-        request.onupgradeneeded = () => {
-          isExisting = false; // Trigger database creation
-        };
-
-        request.onerror = () => {
-          reject(request.error);
-        };
-      });
-
-      await this.#openingDatabase;
-
-      // If database didn't exist, create it
-      if (!isExisting) {
-        await this.#createNewDatabase();
-      }
-    }
+    this.#db = new Map();
   }
 
   async #generateCompositeKey(streamingSessionId: string, eventName: string) {
@@ -81,44 +26,6 @@ class EventSessionDB {
     return hashHex;
   }
 
-  async #init() {
-    return new Promise<void>((resolve, reject) => {
-      this.#removeOldDatabase();
-
-      const uuid = crypto.randomUUID();
-      const name = 'streaming-sessions-' + uuid;
-      this.#name = name;
-      const request = indexedDB.open(name, 1);
-
-      request.onupgradeneeded = () => {
-        this.#db = request.result;
-
-        if (!this.#db.objectStoreNames.contains('events')) {
-          this.#db.createObjectStore('events', {
-            keyPath: 'id',
-          });
-        }
-      };
-
-      request.onsuccess = () => {
-        this.#db = request.result;
-        localStorage.setItem('ssuid', uuid);
-
-        resolve();
-      };
-
-      request.onerror = () => reject(request.error);
-    });
-  }
-
-  #removeOldDatabase() {
-    const ssuid = localStorage.getItem('ssuid');
-
-    if (ssuid) {
-      indexedDB.deleteDatabase('streaming-sessions-' + ssuid);
-    }
-  }
-
   /**
    * Delete a logged event by name and streamingSessionId.
    */
@@ -129,39 +36,14 @@ class EventSessionDB {
     name: string;
     streamingSessionId: string;
   }): Promise<void> {
-    await this.#ensureDatabase();
-
     const compositeKey = await this.#generateCompositeKey(
       streamingSessionId,
       name,
     );
 
-    return new Promise<void>((resolve, reject) => {
-      try {
-        const transaction = this.#db.transaction(['events'], 'readwrite');
-        const store = transaction.objectStore('events');
-        const request = store.delete(compositeKey);
-
-        request.onsuccess = () => resolve();
-
-        request.onerror = () => {
-          throw request.error;
-        };
-      } catch (error) {
-        reject(error);
-      }
-    }).catch(async error => {
-      if (
-        error instanceof DOMException &&
-        error.message.includes('The database connection is closing')
-      ) {
-        await this.#ensureDatabase();
-        return this.delete({
-          name,
-          streamingSessionId,
-        });
-      }
-    });
+    this.#db.delete(compositeKey);
+    console.debug('[EventSessionDB] delete');
+    console.table(Object.fromEntries(this.#db.entries()));
   }
 
   /**
@@ -174,46 +56,15 @@ class EventSessionDB {
     name: string;
     streamingSessionId: string;
   }): Promise<MaybeEvent<P>> {
-    await this.#ensureDatabase();
-
     const compositeKey = await this.#generateCompositeKey(
       streamingSessionId,
       name,
     );
 
-    return new Promise<MaybeEvent<P>>((resolve, reject) => {
-      try {
-        const transaction = this.#db.transaction(['events'], 'readonly');
-        const store = transaction.objectStore('events');
-        const request = store.get(compositeKey);
+    console.debug('[EventSessionDB] get');
+    console.table(Object.fromEntries(this.#db.entries()));
 
-        request.onsuccess = () => {
-          if (request.result) {
-            resolve(request.result as MaybeEvent<P>);
-          } else {
-            resolve(undefined);
-          }
-        };
-
-        request.onerror = () => {
-          throw request.error;
-        };
-      } catch (error) {
-        reject(error);
-      }
-    }).catch(async error => {
-      if (
-        error instanceof DOMException &&
-        error.message.includes('The database connection is closing')
-      ) {
-        await this.#ensureDatabase();
-
-        return this.get<P>({
-          name,
-          streamingSessionId,
-        });
-      }
-    });
+    return this.#db.get(compositeKey);
   }
 
   /**
@@ -225,40 +76,14 @@ class EventSessionDB {
     payload: unknown;
     streamingSessionId: string;
   }): Promise<void> {
-    await this.#ensureDatabase();
-
     const compositeKey = await this.#generateCompositeKey(
       value.streamingSessionId,
       value.name,
     );
 
-    return new Promise<void>((resolve, reject) => {
-      try {
-        const transaction = this.#db.transaction(['events'], 'readwrite');
-        const store = transaction.objectStore('events');
-
-        value.id = compositeKey;
-
-        const request = store.put(value);
-
-        request.onsuccess = () => resolve();
-
-        request.onerror = () => {
-          throw request.error;
-        };
-      } catch (error) {
-        reject(error);
-      }
-    }).catch(async error => {
-      if (
-        error instanceof DOMException &&
-        error.message.includes('The database connection is closing')
-      ) {
-        await this.#ensureDatabase();
-
-        return this.put(value);
-      }
-    });
+    this.#db.set(compositeKey, value);
+    console.debug('[EventSessionDB] put');
+    console.table(Object.fromEntries(this.#db.entries()));
   }
 }
 

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -380,6 +380,11 @@ export class BasePlayer {
   }
 
   finishCurrentMediaProduct(endReason: EndReason) {
+    // A media product was loaded by never started.
+    if (!this.hasStarted()) {
+      return;
+    }
+
     const cssi = this.#currentStreamingSessionId;
     const hasNotBeenFinished = cssi
       ? streamingSessionStore.hasStreamInfo(cssi)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@tidal-music/true-time':
         specifier: workspace:^
         version: link:../true-time
+      '@types/chai':
+        specifier: 4.3.14
+        version: 4.3.14
       '@types/js-levenshtein':
         specifier: 1.1.3
         version: 1.1.3
@@ -1576,6 +1579,9 @@ packages:
 
   '@types/body-parser@1.19.2':
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
+
+  '@types/chai@4.3.14':
+    resolution: {integrity: sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==}
 
   '@types/co-body@6.1.0':
     resolution: {integrity: sha512-3e0q2jyDAnx/DSZi0z2H0yoZ2wt5yRDZ+P7ymcMObvq0ufWRT4tsajyO+Q1VwVWiv9PRR4W3YEjEzBjeZlhF+w==}
@@ -6227,6 +6233,8 @@ snapshots:
     dependencies:
       '@types/connect': 3.4.35
       '@types/node': 20.12.7
+
+  '@types/chai@4.3.14': {}
 
   '@types/co-body@6.1.0':
     dependencies:


### PR DESCRIPTION
- IndexedDB is an unnecessary overhead now and in the future with EventProducer when it takes over the role of sending/storing. Refactored it to an in memory map.
- Prevent sending play log event for load calls with the prefetch flag (on play a new load is made and that session is play logged)