### PR TITLE
Update shaka-player to 4.8.1 with TypeScript support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "pnpm": {
     "patchedDependencies": {
-      "shaka-player@4.7.13": "patches/shaka-player@4.7.13.patch"
+      "shaka-player@4.8.1": "patches/shaka-player@4.8.1.patch"
     }
   }
 }

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -71,7 +71,7 @@
     "js-levenshtein": "1.1.6",
     "mux.js": "6.3.0",
     "rollup": "4.16.1",
-    "shaka-player": "4.7.13",
+    "shaka-player": "4.8.1",
     "sinon": "17.0.1",
     "typescript": "5.4.5",
     "vite": "5.2.10",

--- a/patches/shaka-player@4.8.1.patch
+++ b/patches/shaka-player@4.8.1.patch
@@ -1,23 +1,25 @@
 diff --git a/dist/shaka-player.compiled.d.ts b/dist/shaka-player.compiled.d.ts
-index 9c72e09e9727eac9b32dfce92087b6a4481b1ea7..32a7c646b2040b76ba60d9780618c35f512ece75 100644
+index e6dcbc69da69831c5b327d4ca4a28c4a648caf8a..19c4e9b9d816f5cf12a4e2b8b3d3cf2e326c4e57 100644
 --- a/dist/shaka-player.compiled.d.ts
 +++ b/dist/shaka-player.compiled.d.ts
-@@ -5276,3 +5276,5 @@ declare namespace ಠ_ಠ.clutz {
+@@ -5424,6 +5424,7 @@ declare namespace ಠ_ಠ.clutz {
      static isTypeSupported (keySystem : string , contentType : string ) : boolean ;
    }
  }
-+
 +export default shaka;
+ // Generated from /home/runner/work/shaka-player/shaka-player/externs/webos.js
+ declare namespace PalmSystem {
+   let deviceInfo : string ;
 diff --git a/dist/shaka-player.ui.d.ts b/dist/shaka-player.ui.d.ts
-index face310a3d869dc853764c7802f485c892a01ab6..b56ed09ac7184479cd0ce98248d37673b7e83525 100644
+index 5b3b8753930568a83a6d1d8d6d18357de4d8424a..4301fa807b03741f3384137432cb206df390287b 100644
 --- a/dist/shaka-player.ui.d.ts
 +++ b/dist/shaka-player.ui.d.ts
-@@ -5897,3 +5897,5 @@ declare namespace shaka.extern {
+@@ -6128,3 +6128,4 @@ declare namespace shaka.extern {
  declare namespace shaka.extern {
    type UIVolumeBarColors = { base : string , level : string } ;
  }
-+
 +export default shaka;
+\ No newline at end of file
 diff --git a/index.d.ts b/index.d.ts
 new file mode 100644
 index 0000000000000000000000000000000000000000..86130b219f20157404545f817f41485ab13ced25
@@ -26,15 +28,12 @@ index 0000000000000000000000000000000000000000..86130b219f20157404545f817f41485a
 @@ -0,0 +1,2 @@
 +/// <reference path="./dist/shaka-player.compiled.d.ts" />
 +/// <reference path="./dist/shaka-player.ui.d.ts" />
-diff --git a/package.json b/package.json
-index dee973bb19c28a74c5f13ef11cabe120ff683c02..fc0c9f02d0f931f2ab477dd258c355c60d3300d5 100644
---- a/package.json
-+++ b/package.json
-@@ -106,5 +106,6 @@
-     "remove": [
-       "engines"
-     ]
--  }
-+  },
-+  "types": "dist/shaka-player.compiled.d.ts"
- }
+diff --git a/ui.d.ts b/ui.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..5118563d30558c6692fd35b4f4bd04b6e8874288
+--- /dev/null
++++ b/ui.d.ts
+@@ -0,0 +1,3 @@
++import shaka from './dist/shaka-player.ui'
++export * from './dist/shaka-player.ui'
++export default shaka;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  shaka-player@4.7.13:
-    hash: hlyjm3yroj3ctzscf276uuvclq
-    path: patches/shaka-player@4.7.13.patch
+  shaka-player@4.8.1:
+    hash: rfvab77lcmgxccfhgljk4ro3vq
+    path: patches/shaka-player@4.8.1.patch
 
 importers:
 
@@ -18,7 +18,7 @@ importers:
         version: 8.57.0
       eslint-config-tidal:
         specifier: 3.2.0
-        version: 3.2.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.17.4)
+        version: 3.2.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.31.0)
       eslint-plugin-disable-autofix:
         specifier: 4.3.0
         version: 4.3.0(eslint@8.57.0)
@@ -30,7 +30,7 @@ importers:
         version: 0.25.13(typescript@5.3.3)
       vitest:
         specifier: 1.5.0
-        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
 
   packages/auth:
     dependencies:
@@ -46,7 +46,7 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 1.5.0
-        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4))
+        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0))
       '@vitest/ui':
         specifier: 1.5.0
         version: 1.5.0(vitest@1.5.0)
@@ -55,13 +55,13 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.10
-        version: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+        version: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
       vite-plugin-dts:
         specifier: 3.8.3
-        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.17.4))
+        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.31.0))
       vitest:
         specifier: 1.5.0
-        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
 
   packages/common:
     dependencies:
@@ -71,7 +71,7 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 1.5.0
-        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4))
+        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0))
       '@vitest/ui':
         specifier: 1.5.0
         version: 1.5.0(vitest@1.5.0)
@@ -80,13 +80,13 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.10
-        version: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+        version: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
       vite-plugin-dts:
         specifier: 3.8.3
-        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.17.4))
+        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.31.0))
       vitest:
         specifier: 1.5.0
-        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
 
   packages/event-producer:
     dependencies:
@@ -108,13 +108,13 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 1.5.0
-        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4))
+        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0))
       '@vitest/ui':
         specifier: 1.5.0
         version: 1.5.0(vitest@1.5.0)
       '@vitest/web-worker':
         specifier: 1.5.0
-        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4))
+        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0))
       happy-dom:
         specifier: 14.7.1
         version: 14.7.1
@@ -123,13 +123,13 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.10
-        version: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+        version: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
       vite-plugin-dts:
         specifier: 3.8.3
-        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.17.4))
+        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.31.0))
       vitest:
         specifier: 1.5.0
-        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
       xml-js:
         specifier: 1.6.11
         version: 1.6.11
@@ -138,13 +138,13 @@ importers:
     devDependencies:
       '@babel/preset-env':
         specifier: 7.24.4
-        version: 7.24.4(@babel/core@7.23.2)
+        version: 7.24.4(@babel/core@7.24.5)
       '@babel/preset-typescript':
         specifier: 7.24.1
-        version: 7.24.1(@babel/core@7.23.2)
+        version: 7.24.1(@babel/core@7.24.5)
       '@rollup/plugin-babel':
         specifier: 6.0.4
-        version: 6.0.4(@babel/core@7.23.2)(rollup@4.16.1)
+        version: 6.0.4(@babel/core@7.24.5)(rollup@4.16.1)
       '@rollup/plugin-commonjs':
         specifier: 25.0.7
         version: 25.0.7(rollup@4.16.1)
@@ -212,8 +212,8 @@ importers:
         specifier: 4.16.1
         version: 4.16.1
       shaka-player:
-        specifier: 4.7.13
-        version: 4.7.13(patch_hash=hlyjm3yroj3ctzscf276uuvclq)
+        specifier: 4.8.1
+        version: 4.8.1(patch_hash=rfvab77lcmgxccfhgljk4ro3vq)
       sinon:
         specifier: 17.0.1
         version: 17.0.1
@@ -222,13 +222,13 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.10
-        version: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+        version: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
       vite-plugin-dts:
         specifier: 3.8.3
-        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.17.4))
+        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.31.0))
       vitest:
         specifier: 1.5.0
-        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
 
   packages/player-web-components:
     devDependencies:
@@ -243,7 +243,7 @@ importers:
         version: link:../player
       '@vitest/coverage-v8':
         specifier: 1.5.0
-        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4))
+        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0))
       '@vitest/ui':
         specifier: 1.5.0
         version: 1.5.0(vitest@1.5.0)
@@ -252,13 +252,13 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.10
-        version: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+        version: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
       vite-plugin-dts:
         specifier: 3.8.3
-        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.17.4))
+        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.31.0))
       vitest:
         specifier: 1.5.0
-        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
 
   packages/template:
     dependencies:
@@ -268,7 +268,7 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 1.5.0
-        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4))
+        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0))
       '@vitest/ui':
         specifier: 1.5.0
         version: 1.5.0(vitest@1.5.0)
@@ -277,13 +277,13 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.10
-        version: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+        version: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
       vite-plugin-dts:
         specifier: 3.8.3
-        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.17.4))
+        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.31.0))
       vitest:
         specifier: 1.5.0
-        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
 
   packages/true-time:
     dependencies:
@@ -293,7 +293,7 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: 1.5.0
-        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4))
+        version: 1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0))
       '@vitest/ui':
         specifier: 1.5.0
         version: 1.5.0(vitest@1.5.0)
@@ -302,13 +302,13 @@ importers:
         version: 5.4.5
       vite:
         specifier: 5.2.10
-        version: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+        version: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
       vite-plugin-dts:
         specifier: 3.8.3
-        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.17.4))
+        version: 3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.31.0))
       vitest:
         specifier: 1.5.0
-        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+        version: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
 
 packages:
 
@@ -324,6 +324,10 @@ packages:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@babel/code-frame@7.24.2':
     resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
     engines: {node: '>=6.9.0'}
@@ -332,12 +336,12 @@ packages:
     resolution: {integrity: sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.23.2':
-    resolution: {integrity: sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==}
+  '@babel/core@7.24.5':
+    resolution: {integrity: sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.23.0':
-    resolution: {integrity: sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==}
+  '@babel/generator@7.24.5':
+    resolution: {integrity: sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.22.5':
@@ -405,6 +409,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-module-transforms@7.24.5':
+    resolution: {integrity: sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-optimise-call-expression@7.22.5':
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
@@ -429,6 +439,10 @@ packages:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-simple-access@7.24.5':
+    resolution: {integrity: sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
@@ -437,12 +451,24 @@ packages:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-split-export-declaration@7.24.5':
+    resolution: {integrity: sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.23.4':
     resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.24.1':
+    resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.22.20':
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.24.5':
+    resolution: {integrity: sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.23.5':
@@ -453,8 +479,8 @@ packages:
     resolution: {integrity: sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.23.2':
-    resolution: {integrity: sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==}
+  '@babel/helpers@7.24.5':
+    resolution: {integrity: sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.2':
@@ -463,6 +489,11 @@ packages:
 
   '@babel/parser@7.24.1':
     resolution: {integrity: sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.24.5':
+    resolution: {integrity: sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -926,8 +957,8 @@ packages:
     resolution: {integrity: sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.23.2':
-    resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
+  '@babel/traverse@7.24.5':
+    resolution: {integrity: sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.23.9':
@@ -936,6 +967,10 @@ packages:
 
   '@babel/types@7.24.0':
     resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.24.5':
+    resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -1287,6 +1322,10 @@ packages:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/gen-mapping@0.3.5':
+    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/resolve-uri@3.1.1':
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
     engines: {node: '>=6.0.0'}
@@ -1295,8 +1334,15 @@ packages:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/set-array@1.2.1':
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/source-map@0.3.3':
     resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
+
+  '@jridgewell/source-map@0.3.6':
+    resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
 
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
@@ -1922,6 +1968,11 @@ packages:
 
   acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -4199,8 +4250,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shaka-player@4.7.13:
-    resolution: {integrity: sha512-PTU0lTEx1C8LdyNdZSSTea3Wf1/WT4KJzp6o07CofZqq8fzrGDiWElbir+LQIH1CTZpicO1otJQ24xjPgXz9kg==}
+  shaka-player@4.8.1:
+    resolution: {integrity: sha512-n+VTi+EZ4YWzGOxDy+yqascA6wNEliPy1jIvbHGxW2Prk8fitUozRffsP7aRbyoFwQekJ3D0P+Ngk7nSQU6IZA==}
     engines: {node: '>=14'}
 
   shebang-command@2.0.0:
@@ -4398,6 +4449,11 @@ packages:
 
   terser@5.17.4:
     resolution: {integrity: sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  terser@5.31.0:
+    resolution: {integrity: sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -4919,6 +4975,11 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+
   '@babel/code-frame@7.24.2':
     dependencies:
       '@babel/highlight': 7.24.2
@@ -4926,18 +4987,18 @@ snapshots:
 
   '@babel/compat-data@7.24.4': {}
 
-  '@babel/core@7.23.2':
+  '@babel/core@7.24.5':
     dependencies:
-      '@ampproject/remapping': 2.2.1
+      '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.23.0
+      '@babel/generator': 7.24.5
       '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.2)
-      '@babel/helpers': 7.23.2
-      '@babel/parser': 7.24.1
+      '@babel/helper-module-transforms': 7.24.5(@babel/core@7.24.5)
+      '@babel/helpers': 7.24.5
+      '@babel/parser': 7.24.5
       '@babel/template': 7.24.0
-      '@babel/traverse': 7.23.2
-      '@babel/types': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
       convert-source-map: 2.0.0
       debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
@@ -4946,10 +5007,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.23.0':
+  '@babel/generator@7.24.5':
     dependencies:
-      '@babel/types': 7.24.0
-      '@jridgewell/gen-mapping': 0.3.3
+      '@babel/types': 7.24.5
+      '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
@@ -4969,42 +5030,42 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.24.1(@babel/core@7.23.2)':
+  '@babel/helper-create-class-features-plugin@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.23.2)
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.24.4(@babel/core@7.23.2)':
+  '@babel/helper-create-class-features-plugin@7.24.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.23.2)
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
-  '@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.23.2)':
+  '@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.6.1(@babel/core@7.23.2)':
+  '@babel/helper-define-polyfill-provider@0.6.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.0
       debug: 4.3.4(supports-color@8.1.1)
@@ -5036,14 +5097,23 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.0
 
-  '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.2)':
+  '@babel/helper-module-transforms@7.23.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.24.3
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
+
+  '@babel/helper-module-transforms@7.24.5(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.24.3
+      '@babel/helper-simple-access': 7.24.5
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/helper-validator-identifier': 7.24.5
 
   '@babel/helper-optimise-call-expression@7.22.5':
     dependencies:
@@ -5051,16 +5121,16 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.24.0': {}
 
-  '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.23.2)':
+  '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
 
-  '@babel/helper-replace-supers@7.24.1(@babel/core@7.23.2)':
+  '@babel/helper-replace-supers@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -5068,6 +5138,10 @@ snapshots:
   '@babel/helper-simple-access@7.22.5':
     dependencies:
       '@babel/types': 7.24.0
+
+  '@babel/helper-simple-access@7.24.5':
+    dependencies:
+      '@babel/types': 7.24.5
 
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     dependencies:
@@ -5077,9 +5151,17 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.0
 
+  '@babel/helper-split-export-declaration@7.24.5':
+    dependencies:
+      '@babel/types': 7.24.5
+
   '@babel/helper-string-parser@7.23.4': {}
 
+  '@babel/helper-string-parser@7.24.1': {}
+
   '@babel/helper-validator-identifier@7.22.20': {}
+
+  '@babel/helper-validator-identifier@7.24.5': {}
 
   '@babel/helper-validator-option@7.23.5': {}
 
@@ -5089,11 +5171,11 @@ snapshots:
       '@babel/template': 7.24.0
       '@babel/types': 7.24.0
 
-  '@babel/helpers@7.23.2':
+  '@babel/helpers@7.24.5':
     dependencies:
       '@babel/template': 7.24.0
-      '@babel/traverse': 7.23.2
-      '@babel/types': 7.24.0
+      '@babel/traverse': 7.24.5
+      '@babel/types': 7.24.5
     transitivePeerDependencies:
       - supports-color
 
@@ -5108,536 +5190,540 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.0
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.4(@babel/core@7.23.2)':
+  '@babel/parser@7.24.5':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/types': 7.24.5
+
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.4(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.23.2)
+      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.24.5)
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.2)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-import-assertions@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-import-assertions@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-import-attributes@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-import-attributes@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-jsx@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.23.2)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-arrow-functions@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-arrow-functions@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-async-generator-functions@7.24.3(@babel/core@7.23.2)':
+  '@babel/plugin-transform-async-generator-functions@7.24.3(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.2)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.2)
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.5)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-async-to-generator@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-async-to-generator@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-module-imports': 7.24.3
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.2)
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-block-scoped-functions@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-block-scoped-functions@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-block-scoping@7.24.4(@babel/core@7.23.2)':
+  '@babel/plugin-transform-block-scoping@7.24.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-class-properties@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-class-properties@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-class-static-block@7.24.4(@babel/core@7.23.2)':
+  '@babel/plugin-transform-class-static-block@7.24.4(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-classes@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-classes@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.23.2)
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
 
-  '@babel/plugin-transform-computed-properties@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-computed-properties@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/template': 7.24.0
 
-  '@babel/plugin-transform-destructuring@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-destructuring@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-dotall-regex@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-dotall-regex@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-duplicate-keys@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-duplicate-keys@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-dynamic-import@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-dynamic-import@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-exponentiation-operator@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-exponentiation-operator@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-export-namespace-from@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-export-namespace-from@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-for-of@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-for-of@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  '@babel/plugin-transform-function-name@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-function-name@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-json-strings@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-json-strings@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-literals@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-literals@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.24.0
-
-  '@babel/plugin-transform-logical-assignment-operators@7.24.1(@babel/core@7.23.2)':
-    dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.2)
-
-  '@babel/plugin-transform-member-expression-literals@7.24.1(@babel/core@7.23.2)':
-    dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-modules-amd@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-logical-assignment-operators@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
+
+  '@babel/plugin-transform-member-expression-literals@7.24.1(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-modules-amd@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.24.0
+
+  '@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.24.5)':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-simple-access': 7.22.5
 
-  '@babel/plugin-transform-modules-systemjs@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-modules-systemjs@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.2)
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-identifier': 7.22.20
 
-  '@babel/plugin-transform-modules-umd@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-modules-umd@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.23.2)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-new-target@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-new-target@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-numeric-separator@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-numeric-separator@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.2)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-object-rest-spread@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-object-rest-spread@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.2)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.23.2)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-object-super@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-object-super@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.23.2)
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-optional-catch-binding@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-optional-catch-binding@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-optional-chaining@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-optional-chaining@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-parameters@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-parameters@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-private-methods@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-private-methods@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-private-property-in-object@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-private-property-in-object@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.23.2)
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.2)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-property-literals@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-property-literals@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-regenerator@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-regenerator@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
       regenerator-transform: 0.15.2
 
-  '@babel/plugin-transform-reserved-words@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-reserved-words@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-shorthand-properties@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-shorthand-properties@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-spread@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-spread@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  '@babel/plugin-transform-sticky-regex@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-sticky-regex@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-template-literals@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-template-literals@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-typeof-symbol@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-typeof-symbol@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-typescript@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-typescript@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.23.2)
+      '@babel/helper-create-class-features-plugin': 7.24.1(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.23.2)
+      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.5)
 
-  '@babel/plugin-transform-unicode-escapes@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-unicode-escapes@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-unicode-property-regex@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-unicode-property-regex@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-unicode-regex@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-unicode-regex@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/plugin-transform-unicode-sets-regex@7.24.1(@babel/core@7.23.2)':
+  '@babel/plugin-transform-unicode-sets-regex@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.0
 
-  '@babel/preset-env@7.24.4(@babel/core@7.23.2)':
+  '@babel/preset-env@7.24.4(@babel/core@7.24.5)':
     dependencies:
       '@babel/compat-data': 7.24.4
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.4(@babel/core@7.23.2)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.2)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.2)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.2)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.2)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.2)
-      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-syntax-import-attributes': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.23.2)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.2)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.2)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.2)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.2)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.2)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.2)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.2)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.2)
-      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-async-generator-functions': 7.24.3(@babel/core@7.23.2)
-      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-block-scoped-functions': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-block-scoping': 7.24.4(@babel/core@7.23.2)
-      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-class-static-block': 7.24.4(@babel/core@7.23.2)
-      '@babel/plugin-transform-classes': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-destructuring': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-dotall-regex': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-duplicate-keys': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-dynamic-import': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-exponentiation-operator': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-export-namespace-from': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-for-of': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-json-strings': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-member-expression-literals': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-modules-amd': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-modules-systemjs': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-modules-umd': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.23.2)
-      '@babel/plugin-transform-new-target': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-numeric-separator': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-object-rest-spread': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-object-super': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-optional-catch-binding': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-private-property-in-object': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-property-literals': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-regenerator': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-reserved-words': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-template-literals': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-typeof-symbol': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-unicode-escapes': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-unicode-property-regex': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.1(@babel/core@7.23.2)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.2)
-      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.23.2)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.23.2)
-      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.23.2)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.4(@babel/core@7.24.5)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.5)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.5)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-import-assertions': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-syntax-import-attributes': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.5)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-transform-arrow-functions': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-async-generator-functions': 7.24.3(@babel/core@7.24.5)
+      '@babel/plugin-transform-async-to-generator': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-block-scoping': 7.24.4(@babel/core@7.24.5)
+      '@babel/plugin-transform-class-properties': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-class-static-block': 7.24.4(@babel/core@7.24.5)
+      '@babel/plugin-transform-classes': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-computed-properties': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-destructuring': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-dotall-regex': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-duplicate-keys': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-dynamic-import': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-exponentiation-operator': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-export-namespace-from': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-for-of': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-function-name': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-json-strings': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-literals': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-member-expression-literals': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-amd': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-systemjs': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-umd': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.24.5)
+      '@babel/plugin-transform-new-target': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-numeric-separator': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-object-rest-spread': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-object-super': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-optional-catch-binding': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-optional-chaining': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-parameters': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-private-methods': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-private-property-in-object': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-property-literals': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-regenerator': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-reserved-words': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-shorthand-properties': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-spread': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-sticky-regex': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-template-literals': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-typeof-symbol': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-escapes': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-property-regex': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-regex': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.1(@babel/core@7.24.5)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.5)
+      babel-plugin-polyfill-corejs2: 0.4.10(@babel/core@7.24.5)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.5)
+      babel-plugin-polyfill-regenerator: 0.6.1(@babel/core@7.24.5)
       core-js-compat: 3.36.1
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.2)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/types': 7.24.0
       esutils: 2.0.3
 
-  '@babel/preset-typescript@7.24.1(@babel/core@7.23.2)':
+  '@babel/preset-typescript@7.24.1(@babel/core@7.24.5)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.23.2)
-      '@babel/plugin-transform-typescript': 7.24.1(@babel/core@7.23.2)
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.5)
+      '@babel/plugin-transform-typescript': 7.24.1(@babel/core@7.24.5)
 
   '@babel/regjsgen@0.8.0': {}
 
@@ -5651,16 +5737,16 @@ snapshots:
       '@babel/parser': 7.24.1
       '@babel/types': 7.24.0
 
-  '@babel/traverse@7.23.2':
+  '@babel/traverse@7.24.5':
     dependencies:
       '@babel/code-frame': 7.24.2
-      '@babel/generator': 7.23.0
+      '@babel/generator': 7.24.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.24.1
-      '@babel/types': 7.24.0
+      '@babel/helper-split-export-declaration': 7.24.5
+      '@babel/parser': 7.24.5
+      '@babel/types': 7.24.5
       debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
@@ -5676,6 +5762,12 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
+      to-fast-properties: 2.0.0
+
+  '@babel/types@7.24.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.24.1
+      '@babel/helper-validator-identifier': 7.24.5
       to-fast-properties: 2.0.0
 
   '@bcoe/v8-coverage@0.2.3': {}
@@ -5921,14 +6013,28 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.19
 
+  '@jridgewell/gen-mapping@0.3.5':
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.25
+
   '@jridgewell/resolve-uri@3.1.1': {}
 
   '@jridgewell/set-array@1.1.2': {}
+
+  '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/source-map@0.3.3':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
+
+  '@jridgewell/source-map@0.3.6':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+    optional: true
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
@@ -6041,9 +6147,9 @@ snapshots:
 
   '@redux-saga/types@1.2.1': {}
 
-  '@rollup/plugin-babel@6.0.4(@babel/core@7.23.2)(rollup@4.16.1)':
+  '@rollup/plugin-babel@6.0.4(@babel/core@7.24.5)(rollup@4.16.1)':
     dependencies:
-      '@babel/core': 7.23.2
+      '@babel/core': 7.24.5
       '@babel/helper-module-imports': 7.22.15
       '@rollup/pluginutils': 5.1.0(rollup@4.16.1)
     optionalDependencies:
@@ -6485,7 +6591,7 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitest/coverage-v8@1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4))':
+  '@vitest/coverage-v8@1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0))':
     dependencies:
       '@ampproject/remapping': 2.2.1
       '@bcoe/v8-coverage': 0.2.3
@@ -6500,7 +6606,7 @@ snapshots:
       std-env: 3.6.0
       strip-literal: 2.0.0
       test-exclude: 6.0.0
-      vitest: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+      vitest: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6557,7 +6663,7 @@ snapshots:
       pathe: 1.1.1
       picocolors: 1.0.0
       sirv: 2.0.4
-      vitest: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+      vitest: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
 
   '@vitest/utils@1.1.0':
     dependencies:
@@ -6572,10 +6678,10 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  '@vitest/web-worker@1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4))':
+  '@vitest/web-worker@1.5.0(vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0))':
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
-      vitest: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4)
+      vitest: 1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6817,6 +6923,9 @@ snapshots:
 
   acorn@8.10.0: {}
 
+  acorn@8.11.3:
+    optional: true
+
   agent-base@7.1.0:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
@@ -6992,27 +7101,27 @@ snapshots:
       resolve: 1.22.8
     optional: true
 
-  babel-plugin-polyfill-corejs2@0.4.10(@babel/core@7.23.2):
+  babel-plugin-polyfill-corejs2@0.4.10(@babel/core@7.24.5):
     dependencies:
       '@babel/compat-data': 7.24.4
-      '@babel/core': 7.23.2
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.5)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.23.2):
+  babel-plugin-polyfill-corejs3@0.10.4(@babel/core@7.24.5):
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.5)
       core-js-compat: 3.36.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.23.2):
+  babel-plugin-polyfill-regenerator@0.6.1(@babel/core@7.24.5):
     dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.23.2)
+      '@babel/core': 7.24.5
+      '@babel/helper-define-polyfill-provider': 0.6.1(@babel/core@7.24.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -7657,7 +7766,7 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-config-tidal@3.2.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.17.4):
+  eslint-config-tidal@3.2.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.31.0):
     dependencies:
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.56.0
@@ -7679,13 +7788,13 @@ snapshots:
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.57.0)
       eslint-plugin-storybook: 0.6.15(eslint@8.56.0)(typescript@5.3.3)
-      eslint-plugin-vitest: 0.3.18(@typescript-eslint/eslint-plugin@6.15.0(@typescript-eslint/parser@6.15.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)(vitest@1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.17.4))
+      eslint-plugin-vitest: 0.3.18(@typescript-eslint/eslint-plugin@6.15.0(@typescript-eslint/parser@6.15.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)(vitest@1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.31.0))
       globals: 13.24.0
       prettier: 3.1.1
       redux-saga: 1.2.3
       typed-redux-saga: 1.4.0(redux-saga@1.2.3)
       typescript: 5.3.3
-      vitest: 1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.17.4)
+      vitest: 1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.31.0)
     transitivePeerDependencies:
       - '@edge-runtime/vm'
       - '@types/eslint'
@@ -7895,13 +8004,13 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-vitest@0.3.18(@typescript-eslint/eslint-plugin@6.15.0(@typescript-eslint/parser@6.15.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)(vitest@1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.17.4)):
+  eslint-plugin-vitest@0.3.18(@typescript-eslint/eslint-plugin@6.15.0(@typescript-eslint/parser@6.15.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)(vitest@1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.31.0)):
     dependencies:
       '@typescript-eslint/utils': 6.15.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 6.15.0(@typescript-eslint/parser@6.15.0(eslint@8.56.0)(typescript@5.3.3))(eslint@8.56.0)(typescript@5.3.3)
-      vitest: 1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.17.4)
+      vitest: 1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.31.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9466,7 +9575,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shaka-player@4.7.13(patch_hash=hlyjm3yroj3ctzscf276uuvclq):
+  shaka-player@4.8.1(patch_hash=rfvab77lcmgxccfhgljk4ro3vq):
     dependencies:
       eme-encryption-scheme-polyfill: 2.1.1
 
@@ -9700,6 +9809,14 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  terser@5.31.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.6
+      acorn: 8.11.3
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    optional: true
+
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -9930,13 +10047,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-node@1.1.0(@types/node@20.12.7)(terser@5.17.4):
+  vite-node@1.1.0(@types/node@20.12.7)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+      vite: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9947,13 +10064,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.5.0(@types/node@20.12.7)(terser@5.17.4):
+  vite-node@1.5.0(@types/node@20.12.7)(terser@5.31.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4(supports-color@8.1.1)
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+      vite: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9964,7 +10081,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-dts@3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.17.4)):
+  vite-plugin-dts@3.8.3(@types/node@20.12.7)(rollup@4.16.1)(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.7)(terser@5.31.0)):
     dependencies:
       '@microsoft/api-extractor': 7.43.0(@types/node@20.12.7)
       '@rollup/pluginutils': 5.1.0(rollup@4.16.1)
@@ -9975,13 +10092,13 @@ snapshots:
       typescript: 5.4.5
       vue-tsc: 1.8.27(typescript@5.4.5)
     optionalDependencies:
-      vite: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
+      vite: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@5.2.10(@types/node@20.12.7)(terser@5.17.4):
+  vite@5.2.10(@types/node@20.12.7)(terser@5.31.0):
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.38
@@ -9989,9 +10106,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.7
       fsevents: 2.3.3
-      terser: 5.17.4
+      terser: 5.31.0
 
-  vitest@1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.17.4):
+  vitest@1.1.0(@types/node@20.12.7)(@vitest/ui@1.5.0(vitest@1.5.0))(happy-dom@14.7.1)(terser@5.31.0):
     dependencies:
       '@vitest/expect': 1.1.0
       '@vitest/runner': 1.1.0
@@ -10011,8 +10128,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.5.1
       tinypool: 0.8.2
-      vite: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
-      vite-node: 1.1.0(@types/node@20.12.7)(terser@5.17.4)
+      vite: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
+      vite-node: 1.1.0(@types/node@20.12.7)(terser@5.31.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.12.7
@@ -10027,7 +10144,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.17.4):
+  vitest@1.5.0(@types/node@20.12.7)(@vitest/ui@1.5.0)(happy-dom@14.7.1)(terser@5.31.0):
     dependencies:
       '@vitest/expect': 1.5.0
       '@vitest/runner': 1.5.0
@@ -10046,8 +10163,8 @@ snapshots:
       strip-literal: 2.0.0
       tinybench: 2.5.1
       tinypool: 0.8.4
-      vite: 5.2.10(@types/node@20.12.7)(terser@5.17.4)
-      vite-node: 1.5.0(@types/node@20.12.7)(terser@5.17.4)
+      vite: 5.2.10(@types/node@20.12.7)(terser@5.31.0)
+      vite-node: 1.5.0(@types/node@20.12.7)(terser@5.31.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.12.7


### PR DESCRIPTION
- Update shaka-player to version 4.8.1
- Remake the patch with [`pnpm patch`](https://pnpm.io/cli/patch) based on https://gist.github.com/Security2431/2b28f17e11870bb4b0e347673e16d5ba