### PR TITLE
Removed internal api from auth example

### DIFF
--- a/packages/auth/examples/authorization-code.html
+++ b/packages/auth/examples/authorization-code.html
@@ -12,6 +12,10 @@
     #forceRefreshBtn {
       max-width: 300px;
     }
+
+    #searchField {
+      margin-top: 20px;
+    }
   </style>
 </head>
 
@@ -42,8 +46,13 @@
   <div id="userInfo"></div>
 
   <button id="logoutBtn">Logout</button>
-  <button id="getUserBtn">Get user</button>
   <button id="forceRefreshBtn">Force Refresh (sub status)</button>
+
+  <label>
+    <input type="search" name="search" placeholder="search for artists" id="searchField" />
+  </label>
+
+  <ul id="searchResults"></ul>
 
   <script type="module" src="./authorization-code.js"></script>
 </body>

--- a/packages/auth/examples/authorization-code.js
+++ b/packages/auth/examples/authorization-code.js
@@ -1,10 +1,11 @@
 import { finalizeLogin, init, initializeLogin, logout } from '../dist';
 
-import { getUserInfo } from './shared';
+import { debounce, getUserInfo, searchForArtist } from './shared';
 
 window.addEventListener('load', () => {
   const form = document.getElementById('authorizationCodeForm');
   const logoutButton = document.getElementById('logoutBtn');
+  const searchField = document.getElementById('searchField');
 
   form?.addEventListener('submit', event => {
     submitHandler(event).catch(error => console.error(error));
@@ -17,6 +18,17 @@ window.addEventListener('load', () => {
   });
 
   loadHandler().catch(error => console.error(error));
+
+  searchField?.addEventListener(
+    'keyup',
+    debounce(event => {
+      if (event.target.value.length > 0) {
+        searchForArtist(event.target.value).catch(error =>
+          console.error(error),
+        );
+      }
+    }, 500),
+  );
 });
 
 const submitHandler = async event => {
@@ -63,18 +75,11 @@ const loadHandler = async () => {
       window.location.replace('/examples/authorization-code.html');
     } else {
       await getUserInfo();
-      document.getElementById('getUserBtn').style.display = 'block';
+      document.getElementById('searchField').style.display = 'block';
       document.getElementById('forceRefreshBtn').style.display = 'block';
     }
   }
 };
-
-document.getElementById('getUserBtn')?.addEventListener('click', () => {
-  const userInfo = document.getElementById('userInfo');
-  // clear userInfo to make sure its filled again
-  userInfo.innerHTML = '';
-  getUserInfo().catch(error => console.error(error));
-});
 
 document.getElementById('forceRefreshBtn')?.addEventListener('click', () => {
   const userInfo = document.getElementById('userInfo');


### PR DESCRIPTION
After we got a report (#119) that the authroization code example (formerly called "login redirect") doesn't work I started digging. We found out that in the example code I used an internal api to get e.g. the userId. 

I changed the example code to use the same endpoint (search) to demonstrate the token is working.
Alongside we are also extracting the userId from the access token, which is only present in this flow and not at e.g. client credentials.

Also fixed some minor type issues in the js doc comments in `shared.js`