### PR TITLE
Enforce changelog update when version bump detected 

### DIFF
--- a/.github/scripts/CheckChangelogs.main.kts
+++ b/.github/scripts/CheckChangelogs.main.kts
@@ -1,0 +1,27 @@
+#!/usr/bin/env kotlin
+
+@file:DependsOn("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.0")
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import java.io.File
+
+data class Module(val name: String, val version: String)
+
+val modulesWithVersionsJson = args[0]
+
+val modules: List<Module> = jacksonObjectMapper().readValue(modulesWithVersionsJson)
+
+for (module in modules) {
+    val moduleName = module.name
+    val version = module.version
+    val pattern = Regex("## \\[$version\\]")
+    val changelogContent = File("./$moduleName/CHANGELOG.md").readText()
+    if (pattern.containsMatchIn(changelogContent)) {
+        println("✅ Version string $version found in CHANGELOG.md for module $moduleName")
+    } else {
+        println("⛔️ String $version not found in CHANGELOG.md for module $moduleName")
+        System.exit(1)
+    }
+}
+

--- a/.github/workflows/check-changelog-files.yml
+++ b/.github/workflows/check-changelog-files.yml
@@ -1,0 +1,40 @@
+name: Check version bump and changelog files
+
+on:
+  workflow_call:
+    
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    name: Enforce changelog files update
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files
+        id: changed-files 
+        uses: tj-actions/changed-files@v44
+        with:
+          files: packages/**/package.json
+      - name: Build matrix input
+        id: build-matrix
+        if: ${{ steps.changed-files.outputs.all_changed_files }} != '[]'
+        run: |
+          set +e
+          modules_list=()
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            ./bin/check-version-bump.sh ./"$file"
+
+            # check-version-bump exits with 0 if it detects a bump, otherwise with 1
+            if [ $? != "1" ] && [[ ! " ${modules_list[*]} " =~ " ${file} " ]]; then
+              version="$(cat $file | jq -r '.version')"
+              modules_list+=("{\"name\": \"${file%"/package.json"}\", \"version\": \"$version\"}")
+            fi
+          done
+
+          jsonString="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${modules_list[@]}")"
+          echo $jsonString
+          echo "modules=$jsonString" >> $GITHUB_OUTPUT
+
+      - name: Check changelog files
+        if: ${{ steps.build-matrix.outputs.modules != '' }}
+        run: |
+          kotlinc -script .github/scripts/CheckChangelogs.main.kts ${{ steps.build-matrix.outputs.modules}}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,3 +21,7 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/unit-test.yml
     secrets: inherit
+
+  trigger-changelogs-check:
+    name: Trigger changelog files check
+    uses: ./.github/workflows/check-changelog-files.yml

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ And follow the prompts.
     ```
     Change `version` to the new value. Follow [Semantic Versioning](https://semver.org/). Also, you cannot downgrade - the CI/CD pipeline will refuse to work with downgrades.
 
-2. Open a Pull Request with your version bump, get it approved and merge it. A release draft will be created for the module you changed.
+2. Update the module's changelog file with the changes that will be introduced in the new version.
 
-3. Find your draft in the [releases list](https://github.com/tidal-music/tidal-sdk-web/releases) and add some meaningful sentences about the release, changelog style (Note: We should automate and regulate changelog creation, but for now, you are free to just type).
+3. Open a Pull Request with your version bump and changelog update, get it approved and merge it. A release draft will be created for the module you changed.
 
-4. Check in with your teammates, lead, the module's owner etc. to make sure the release is ready to go.
+4. Find your draft in the [releases list](https://github.com/tidal-music/tidal-sdk-web/releases) and add some meaningful sentences about the release, changelog style (Note: We should automate and regulate changelog creation, but for now, you are free to just type).
 
-5. Click `Publish` at the bottom of your draft release. This will trigger a workflow to tag the release commit and attach artifacts to the release. It will also trigger publishing the package to `Npm`, where it should appear under [@tidal-music Npm org](https://www.npmjs.com/org/tidal-music) shortly!
+5. Check in with your teammates, lead, the module's owner etc. to make sure the release is ready to go.
+
+6. Click `Publish` at the bottom of your draft release. This will trigger a workflow to tag the release commit and attach artifacts to the release. It will also trigger publishing the package to `Npm`, where it should appear under [@tidal-music Npm org](https://www.npmjs.com/org/tidal-music) shortly!

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-04-16
+## [1.3.0] - 2024-04-16
 
 ### Changed
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-04-16
+## [0.1.5] - 2024-03-01
 
 ### Changed
 
-- Use of the new TrueTime module
+- Minor types update

--- a/packages/event-producer/CHANGELOG.md
+++ b/packages/event-producer/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-04-16
+## [2.2.0] - 2024-04-19
 
-### Changed
+### Fixed
 
-- Use of the new TrueTime module
+- Event Producer timestamps are now integer values which fixes an ingestion error for CDF events and a warning for older style events.

--- a/packages/player-web-components/CHANGELOG.md
+++ b/packages/player-web-components/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-04-16
+## [0.1.1] - 2024-01-22
 
-### Changed
+### Fixed
 
-- Use of the new TrueTime module
+- Fixed package.json metadata

--- a/packages/true-time/CHANGELOG.md
+++ b/packages/true-time/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-04-16
+## [0.3.0] - 2024-04-16
 
 ### Changed
 
-- Use of the new TrueTime module
+- Change that will avoid trueTime.now() throwing errors, hopefully making it easier to use.


### PR DESCRIPTION
- Added changelog files to all the modules
- Added a check for changelog files to the pull request workflow. If a version bump is detected, it verifies that the new version is mentioned in the module's changelog file.