### PR TITLE
Fix omitting clientUniqueKey (was sent as empty string)

### DIFF
--- a/packages/auth/examples/authorization-code.js
+++ b/packages/auth/examples/authorization-code.js
@@ -45,7 +45,6 @@ const submitHandler = async event => {
 
   await init({
     clientId,
-    clientUniqueKey: 'test',
     credentialsStorageKey: 'authorizationCode',
   });
 
@@ -66,7 +65,6 @@ const loadHandler = async () => {
 
     await init({
       clientId,
-      clientUniqueKey: 'test',
       credentialsStorageKey: 'authorizationCode',
     });
 

--- a/packages/auth/src/auth/auth.test.ts
+++ b/packages/auth/src/auth/auth.test.ts
@@ -296,6 +296,32 @@ describe.sequential('auth', () => {
       expect(result).toBeUndefined();
     });
 
+    it('does not send a clientUniqueKey when omitted', async () => {
+      // make sure `init` gets the correct values from storage
+      vi.mocked(storage.loadCredentials).mockResolvedValue(fixtures.storage);
+      vi.mocked(fetchHandling.handleTokenFetch).mockResolvedValue(
+        new Response(JSON.stringify(fixtures.userJsonResponse)), // oauth/token
+      );
+
+      await init({ ...initConfig, clientUniqueKey: undefined });
+
+      const result = await finalizeLogin('code=foobar');
+      expect(storage.saveCredentialsToStorage).toHaveBeenCalled();
+      expect(fetchHandling.handleTokenFetch).toHaveBeenCalledWith({
+        body: {
+          client_id: 'CLIENT_ID',
+          client_secret: 'CLIENT_SECRET',
+          code: 'foobar',
+          code_verifier: 'CODE_CHALLENGE',
+          grant_type: 'authorization_code',
+          redirect_uri: 'https://redirect.uri',
+          scope: 'READ WRITE',
+        },
+        credentials: { ...fixtures.storage, clientUniqueKey: undefined },
+      });
+      expect(result).toBeUndefined();
+    });
+
     it('requests an auth token and handles retryableError', async () => {
       // make sure `init` gets the correct values from storage
       vi.mocked(storage.loadCredentials).mockResolvedValue(fixtures.storage);

--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -254,7 +254,9 @@ export const finalizeLogin = async (loginResponseQuery: string) => {
 
   const body = {
     client_id: clientId,
-    client_unique_key: clientUniqueKey ?? '',
+    ...(clientUniqueKey && {
+      client_unique_key: clientUniqueKey,
+    }),
     ...(clientSecret && {
       client_secret: clientSecret,
     }),
@@ -304,6 +306,9 @@ export const finalizeDeviceLogin = async () => {
     client_id: clientId,
     ...(clientSecret && {
       client_secret: clientSecret,
+    }),
+    ...(clientUniqueKey && {
+      client_unique_key: clientUniqueKey,
     }),
     client_unique_key: clientUniqueKey ?? '',
     device_code: deviceCode,

--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -310,7 +310,6 @@ export const finalizeDeviceLogin = async () => {
     ...(clientUniqueKey && {
       client_unique_key: clientUniqueKey,
     }),
-    client_unique_key: clientUniqueKey ?? '',
     device_code: deviceCode,
     grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
     scope: scopes.join(' '),


### PR DESCRIPTION
During testing we found out, that not providing the `clientUniqueKey` leads no an error. Problem was we were still sending the param to the API, but as an empty string.

This PR cleans that up and adds a test for the case.