### PR TITLE
chore(deps): bump eslint-plugin-disable-autofix for eslint v9 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "eslint": "8.57.0",
     "eslint-config-tidal": "3.2.0",
-    "eslint-plugin-disable-autofix": "4.3.0",
+    "eslint-plugin-disable-autofix": "5.0.1",
     "eslint-plugin-jsdoc": "48.2.6",
     "typedoc": "0.25.13",
     "vitest": "1.6.0"


### PR DESCRIPTION
Users have had issues with `eslint-plugin-disable-autofix` failing with @eslint v9. I have published an update to extend the compatibility to v9. It can still be used with v8 but I wanted to open this PR at least as a reminder for when the migration to v9 is completed since I noticed the config here is already done, if the plugin is not updated it will possibly throw an error!