### PR TITLE
Removing adding passed scopes when using client credentials

### DIFF
--- a/packages/auth/src/auth/auth.test.ts
+++ b/packages/auth/src/auth/auth.test.ts
@@ -553,6 +553,28 @@ describe.sequential('auth', () => {
       });
     });
 
+    it('use client credentials to retrieve token, omitting passed scopes', async () => {
+      vi.spyOn(trueTime, 'now').mockReturnValue(fixtures.expiresTimerMock);
+      vi.mocked(fetchHandling.handleTokenFetch).mockResolvedValue(
+        new Response(JSON.stringify(fixtures.clientCredentialsJsonResponse)),
+      );
+      vi.mocked(fetchHandling.prepareFetch).mockReturnValue(prepareFetchMock);
+
+      await init({
+        ...initConfig,
+        clientSecret: 'CLIENT_SECRET',
+      });
+
+      const accessToken = await getCredentials();
+
+      expect(fetchHandling.handleTokenFetch).toHaveBeenCalled();
+      expect(accessToken).toEqual({
+        ...fixtures.storageClientCredentials.accessToken,
+        clientUniqueKey: 'CLIENT_UNIQUE_KEY',
+        requestedScopes: ['READ', 'WRITE'],
+      });
+    });
+
     it('get the right token from storage and return it', async () => {
       vi.mocked(storage.loadCredentials).mockResolvedValue(fixtures.storage);
       vi.spyOn(trueTime, 'now').mockReturnValue(0); // make sure token isn't expired

--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -453,7 +453,6 @@ const getTokenThroughClientCredentials = async () => {
       client_id: state.credentials.clientId,
       client_secret: state.credentials.clientSecret,
       grant_type: 'client_credentials',
-      scope: state.credentials.scopes.join(' '),
     };
 
     const response = await handleTokenFetch({


### PR DESCRIPTION
Client credentials doesn't support scopes, therefore we remove passing it. This should make it simpler to change auth methods to e.g. PKCE after init.