### PR TITLE
Omitting scope validity check for client credentials

### DIFF
--- a/packages/auth/src/auth/auth.test.ts
+++ b/packages/auth/src/auth/auth.test.ts
@@ -565,10 +565,15 @@ describe.sequential('auth', () => {
         clientSecret: 'CLIENT_SECRET',
       });
 
-      const accessToken = await getCredentials();
-
+      expect(await getCredentials()).toEqual({
+        ...fixtures.storageClientCredentials.accessToken,
+        clientUniqueKey: 'CLIENT_UNIQUE_KEY',
+        requestedScopes: ['READ', 'WRITE'],
+      });
       expect(fetchHandling.handleTokenFetch).toHaveBeenCalled();
-      expect(accessToken).toEqual({
+
+      // second time access token is requested, scope check needs to be skipped for client credentials
+      expect(await getCredentials()).toEqual({
         ...fixtures.storageClientCredentials.accessToken,
         clientUniqueKey: 'CLIENT_UNIQUE_KEY',
         requestedScopes: ['READ', 'WRITE'],

--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -518,7 +518,7 @@ const getCredentialsInternal = async (apiErrorSubStatus?: string) => {
 
       if (
         state.credentials.clientUniqueKey !== accessToken.clientUniqueKey ||
-        newScopeIsSameOrSubset === false
+        (accessToken.userId && newScopeIsSameOrSubset === false)
       ) {
         logout();
         throw new IllegalArgumentError(authErrorCodeMap.illegalArgumentError);


### PR DESCRIPTION
To follow up #175 we are now also remove the scope check for client credentials.