### PR TITLE
[Player] Release v0.4.2

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -5,13 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.1] - 2024-08.07
+## [0.4.2] - 2024-08-21
+
+### Changed
+
+- More solid fix for demo content in safari (#173)
+- Fix transitions from MAX in native player to LOW/HIGH in shaka player causing playback to stop (#177)
+- Fix some transitions between players causing reset to not work correctly leading to simultaneous playback (#177)
+
+## [0.4.1] - 2024-08-07
 
 ### Changed
 
 - Instantiates Shaka with the correct config for FairPlay depending on initial item loaded
 
-## [0.4.0] - 2024-07.25
+## [0.4.0] - 2024-07-25
 
 ### Changed
 

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/player",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Player logic for TIDAL",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## [0.4.2] - 2024-08-21

### Changed

- More solid fix for demo content in safari (#173)
- Fix transitions from MAX in native player to LOW/HIGH in shaka player causing playback to stop (#177)
- Fix some transitions between players causing reset to not work correctly leading to simultaneous playback (#177)