### PR TITLE
MF-315: Prevent the web from setting the device in state when setting the device fails in player.

### DIFF
--- a/packages/player/src/player/nativePlayer.ts
+++ b/packages/player/src/player/nativePlayer.ts
@@ -675,8 +675,7 @@ export default class NativePlayer extends BasePlayer {
         this.#currentOutputId = sinkId;
       }
     } else {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      console.warn(`Device with sinkId ${sinkId} not found.`);
+      throw new Error(`Device with sinkId ${sinkId} not found.`);
     }
 
     return Promise.resolve();


### PR DESCRIPTION
This fixes one of the conditions in which users are kicked out of exclusive mode. I think this is the main condition.

I tested this with the boombox playlist and quite a lot of connecting and disconnecting.

This PR is combined with: https://github.com/tidal-engineering/webclient-app/pull/5554