### PR TITLE
Bump version to create a release

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2024-09-10
+
+### Changed
+
+- Device restoration failure now throws an error to prevent further actions related to device change.
+
 ## [0.4.2] - 2024-08-21
 
 ### Changed

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/player",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Player logic for TIDAL",
   "type": "module",
   "exports": {


### PR DESCRIPTION
This is to fix the problem where a user is thrown out of exclusive mode when restoring device settings on the player.