### PR TITLE
Use auth header for non-demo requests too

### DIFF
--- a/packages/player/src/player/shakaPlayer.ts
+++ b/packages/player/src/player/shakaPlayer.ts
@@ -480,20 +480,10 @@ export default class ShakaPlayer extends BasePlayer {
           }
         }
 
-        // Manipulate manifest and segment requests that are sent to
-        // fsu.fa.tidal.com or ugcf.fa.tidal.com
-        const isRequestToFsuOrUgcf =
-          Array.isArray(request.uris) &&
-          request.uris.find(
-            uri =>
-              uri.startsWith('https://fsu.fa.tidal.com') ||
-              uri.startsWith('https://ugcf.fa.tidal.com'),
-          );
-
         if (
-          (type === shaka.net.NetworkingEngine.RequestType.MANIFEST ||
-            type === shaka.net.NetworkingEngine.RequestType.SEGMENT) &&
-          isRequestToFsuOrUgcf
+          type === shaka.net.NetworkingEngine.RequestType.MANIFEST ||
+          type === shaka.net.NetworkingEngine.RequestType.LICENSE ||
+          type === shaka.net.NetworkingEngine.RequestType.SEGMENT
         ) {
           const { token } =
             await credentialsProviderStore.credentialsProvider.getCredentials();


### PR DESCRIPTION
For playback in third party apps to work we need the auth header on the widevine requests.