### PR TITLE
Settings cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"
     },
-    "eslint.experimental.useFlatConfig": true,
+    "eslint.useFlatConfig": true,
     "cSpell.words": [
       "Retryable",
       "typecheck"

--- a/package.json
+++ b/package.json
@@ -22,14 +22,6 @@
     "typedoc": "0.26.7",
     "vitest": "2.0.4"
   },
-  "prettier": {
-    "arrowParens": "avoid",
-    "singleQuote": true,
-    "trailingComma": "all"
-  },
-  "workspaces": [
-    "packages/*"
-  ],
   "pnpm": {
     "patchedDependencies": {
       "shaka-player@4.11.2": "patches/shaka-player@4.11.2.patch"

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
     "config:recommended"
   ],
   "ignoreDeps": [
-    "shaka-player",
-    "openapi-fetch"
+    "shaka-player"
   ],
   "packageRules": [{
     "description": "Group Npm packages",


### PR DESCRIPTION
* PNPM reads workspaces from config file (so remove from `package.json`)
* Remove Prettier config from `package.json` (should be read from eslint-config package)
* Stop blocking `openapi-fetch` updates in Renovate (as we are now on latest `openapi-typescript`)
* Update eslint vscode configuration (no longer experimental)