### PR TITLE
[Player] Release v0.5.1

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-09-25
+
+### Changed
+
+- Rework reset state for native player to avoid incorrect states. (Could be the trigger for various "wrong track displayed" issues.)
+
+
 ## [0.5.0] - 2024-09-18
 
 ### Changed

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/player",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Player logic for TIDAL",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## [0.5.1] - 2024-09-25

### Changed

- Rework reset state for native player to avoid incorrect states. (Could be the trigger for various "wrong track displayed" issues.)
