### PR TITLE
Version 0.5.2

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2024-10-02
+
+### Fixed
+
+- Handle products that are not preloadable in the shaka-player PreloadManager.
+
+
 ## [0.5.1] - 2024-09-25
 
 ### Changed

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/player",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Player logic for TIDAL",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## [0.5.2] - 2024-10-02

### Fixed

- Handle products that are not preloadable in the shaka-player PreloadManager.
