### PR TITLE
[Player] Fix steaming-session-id linked to wrong playback info on some preloads

### DIFF
--- a/packages/player/src/internal/handlers/set-next.ts
+++ b/packages/player/src/internal/handlers/set-next.ts
@@ -40,8 +40,7 @@ async function _setNext(
     return unloadPreloadedMediaProduct();
   }
 
-  let streamingSessionId =
-    playerState.preloadedStreamingSessionId ?? generateGUID();
+  const streamingSessionId = generateGUID();
 
   // For repeat playbacks, we clone the streaming session to a new streaming session id.
   if (
@@ -52,8 +51,6 @@ async function _setNext(
       playerState.preloadedStreamingSessionId,
     )
   ) {
-    streamingSessionId = generateGUID();
-
     streamingSessionStore.clone(
       playerState.preloadedStreamingSessionId,
       streamingSessionId,

--- a/packages/player/src/player/shakaPlayer.ts
+++ b/packages/player/src/player/shakaPlayer.ts
@@ -1065,7 +1065,19 @@ export default class ShakaPlayer extends BasePlayer {
     );
 
     if (this.#preloadedPayload) {
-      const { mediaProduct, playbackInfo, streamInfo } = this.#preloadedPayload;
+      const {
+        mediaProduct: mediaProductFromLoadPayload,
+        playbackInfo,
+        streamInfo,
+      } = this.#preloadedPayload;
+
+      const mediaProductTransition =
+        streamingSessionStore.getMediaProductTransition(
+          streamInfo.streamingSessionId,
+        );
+
+      const mediaProduct =
+        mediaProductTransition?.mediaProduct ?? mediaProductFromLoadPayload;
 
       return this.#loadAndDispatchMediaProductTransition({
         assetPosition: 0,


### PR DESCRIPTION
Fix steaming-session-id linked to wrong playback info on some preloads. Causing some instances of wrong media product transitions with setNext in various cases.