### PR TITLE
Listen to correct Auth event in Player

### DIFF
--- a/packages/player/src/internal/index.ts
+++ b/packages/player/src/internal/index.ts
@@ -29,7 +29,7 @@ class CredentialsProviderStore extends EventTarget {
 
     this.#credentialsProvider.bus(event => {
       switch (event.detail.type) {
-        case 'credentialsUpdated':
+        case 'CredentialsUpdatedMessage':
           this.dispatchAuthorized().catch(console.error);
           break;
         default:


### PR DESCRIPTION
The `CredentialsProvider` from the Auth module uses a different event `type` (name) than the Player module was expecting.