### PR TITLE
Add handler for getNextMediaProduct

### DIFF
--- a/packages/player/src/api/index.ts
+++ b/packages/player/src/api/index.ts
@@ -1,6 +1,7 @@
 export { getAssetPosition } from '../internal/handlers/get-asset-position';
 export { getLoudnessNormalizationMode } from '../internal/handlers/get-loudness-normalization-mode';
 export { getMediaProduct } from '../internal/handlers/get-media-product';
+export { getNextMediaProduct } from '../internal/handlers/get-next-media-product';
 export { getOutputDevices } from '../internal/handlers/get-output-devices';
 export { getPlaybackContext } from '../internal/handlers/get-playback-context';
 export { getPlaybackState } from '../internal/handlers/get-playback-state';

--- a/packages/player/src/internal/handlers/get-media-product.test.ts
+++ b/packages/player/src/internal/handlers/get-media-product.test.ts
@@ -20,7 +20,6 @@ describe('getMediaProduct', () => {
     this.timeout(10000);
 
     const test = async () => {
-      console.debug('loading');
       await Player.load(
         {
           productId: '141120674',
@@ -30,18 +29,12 @@ describe('getMediaProduct', () => {
         },
         0,
       );
-      console.debug('load done');
 
-      console.debug('play');
       await Player.play();
-      console.debug('playing');
 
-      console.debug('waiting 2000');
-      await waitFor(2000);
+      await waitFor(500);
 
       const activeMediaProduct = getMediaProduct();
-
-      console.debug({ activeMediaProduct });
 
       expect(activeMediaProduct).to.equal({
         productId: '141120674',

--- a/packages/player/src/internal/handlers/get-next-media-product.test.ts
+++ b/packages/player/src/internal/handlers/get-next-media-product.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+
+import * as Player from '../../index';
+import { waitFor } from '../../test-helpers';
+
+import { getNextMediaProduct } from './get-next-media-product';
+
+describe('getMediaProduct', () => {
+  beforeEach(async () => {
+    await Player.reset();
+  });
+
+  it('returns null if there is no active player', () => {
+    const nextMediaProduct = getNextMediaProduct();
+
+    expect(nextMediaProduct).to.equal(null);
+  });
+
+  it('returns null if there is nothing set as next', async () => {
+    await Player.load(
+      {
+        productId: '141120674',
+        productType: 'track',
+        sourceId: 'tidal-player-tests',
+        sourceType: 'tidal-player-tests',
+      },
+      0,
+    );
+
+    await Player.play();
+    await waitFor(500);
+
+    const nextMediaProduct = getNextMediaProduct();
+
+    expect(nextMediaProduct).to.equal(null);
+  });
+
+  it('returns the media product that was set as next', async () => {
+    const mediaProduct1: Player.MediaProduct = {
+      productId: '141120674',
+      productType: 'track',
+      sourceId: 'tidal-player-tests',
+      sourceType: 'tidal-player-tests',
+    };
+    const mediaProduct2: Player.MediaProduct = {
+      productId: '3142609',
+      productType: 'track',
+      sourceId: 'tidal-player-tests',
+      sourceType: 'tidal-player-tests',
+    };
+
+    await Player.load(mediaProduct1, 0);
+
+    await Player.play();
+
+    await waitFor(500);
+
+    await Player.setNext(mediaProduct2);
+
+    const nextMediaProduct = getNextMediaProduct();
+
+    expect(nextMediaProduct).to.equal(mediaProduct2);
+  });
+});

--- a/packages/player/src/internal/handlers/get-next-media-product.ts
+++ b/packages/player/src/internal/handlers/get-next-media-product.ts
@@ -1,0 +1,15 @@
+import type { MediaProduct } from '../../api/interfaces';
+import { playerState } from '../../player/state';
+
+/**
+ * Gets the next media product. This is the same value as
+ * was included in the last successful call to setNext.
+ *
+ * Gets unset to return null on media-product-transition and
+ * on player resets.
+ *
+ * @returns {MediaProduct | null}
+ */
+export function getNextMediaProduct(): MediaProduct | null {
+  return playerState.preloadedMediaProduct ?? null;
+}


### PR DESCRIPTION
Currently applications using the Web SDK needs to store and maintain their own state with regards to if something has been [set as next](https://github.com/tidal-music/tidal-sdk-web/blob/main/packages/player/src/internal/handlers/set-next.ts) or not. This PR adds a method - `getNextMediaProduct()` - that returns a `MediaProduct | null`.
