### PR TITLE
Fix exports order

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,8 +13,8 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    "default": "./dist/index.js",
-    "import": "./dist/index.js"
+    "import": "./dist/index.js",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "prepare": "vite build",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,8 +13,8 @@
   "module": "dist/index.js",
   "exports": {
     "import": "./dist/index.js",
-    "default": "./dist/index.js",
-    "legacy": "./dist/legacy/index.js"
+    "legacy": "./dist/legacy/index.js",
+    "default": "./dist/index.js"
   },
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/event-producer/package.json
+++ b/packages/event-producer/package.json
@@ -14,8 +14,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     "import": "./dist/index.js",
-    "default": "./dist/index.js",
-    "legacy": "./dist/legacy/index.js"
+    "legacy": "./dist/legacy/index.js",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "prepare": "vite build",

--- a/packages/player-web-components/package.json
+++ b/packages/player-web-components/package.json
@@ -13,8 +13,8 @@
   },
   "license": "Apache-2.0",
   "exports": {
-    "default": "./dist/index.js",
-    "import": "./dist/index.js"
+    "import": "./dist/index.js",
+    "default": "./dist/index.js"
   },
   "keywords": [
     "tidal-music",

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "exports": {
     "import": "./dist/index.js",
-    "default": "./dist/index.js",
-    "legacy": "./dist/legacy/index.js"
+    "legacy": "./dist/legacy/index.js",
+    "default": "./dist/index.js"
   },
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -14,8 +14,8 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    "default": "./dist/index.js",
-    "import": "./dist/index.js"
+    "import": "./dist/index.js",
+    "default": "./dist/index.js"
   },
   "scripts": {
     "prepare": "vite build",


### PR DESCRIPTION
According to build output, `default` should be the last entry to not override others.