### PR TITLE
Switch to safe version of `tj-actions/changed-files`

### DIFF
--- a/.github/workflows/check-changelog-files.yml
+++ b/.github/workflows/check-changelog-files.yml
@@ -2,7 +2,7 @@ name: Check version bump and changelog files
 
 on:
   workflow_call:
-    
+
 jobs:
   check-version-bump:
     runs-on: ubuntu-latest
@@ -10,8 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get changed files
-        id: changed-files 
-        uses: tj-actions/changed-files@v45
+        id: changed-files
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files: packages/**/package.json
       - name: Build matrix input

--- a/.github/workflows/trigger-releases.yml
+++ b/.github/workflows/trigger-releases.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: main
 
-jobs: 
+jobs:
   check-changes:
     runs-on: ubuntu-latest
     name: Check Changed Files
@@ -12,8 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Get changed files
-        id: changed-files 
-        uses: tj-actions/changed-files@v45
+        id: changed-files
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files: packages/**/package.json
       - name: Build matrix input
@@ -33,13 +33,13 @@ jobs:
 
           jsonString="$(jq --compact-output --null-input '$ARGS.positional' --args -- "${modules_list[@]}")"
           echo "modules=$jsonString" >> $GITHUB_OUTPUT
-          
+
   trigger-lint:
     name: Run Lint Checks
     needs: [ check-changes ]
     if: ${{ needs.check-changes.outputs.modules != '' && toJson(fromJson(needs.check-changes.outputs.modules)) != '[]' }}
     uses: ./.github/workflows/lint.yml
-      
+
   trigger-unit-tests:
     name: Run Unit Tests
     needs: [ check-changes ]
@@ -56,8 +56,6 @@ jobs:
       matrix:
         module: ${{ fromJSON(needs.check-changes.outputs.modules) }}
     uses: ./.github/workflows/create-release.yml
-    with: 
+    with:
         module: ${{ matrix.module }}
     secrets: inherit
-
-


### PR DESCRIPTION
As there was a security issue with the package: https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/

We should switch to use git SHAs for all actions used.