### PR TITLE
Player: Add optional `extras` attribute to MediaProduct and propagate through event tracking

### DIFF
--- a/packages/player/src/api/interfaces.ts
+++ b/packages/player/src/api/interfaces.ts
@@ -53,6 +53,8 @@ export type { AudioQuality } from '../internal/types';
  * Contains information about a TIDAL media product.
  */
 export type MediaProduct = {
+  /** Optional extra attributes of the media product. Passed through to corresponding PlayLog event */
+  extras?: Record<string, unknown>;
   /** The id of the product to play */
   productId: string;
   /** The type of the product to play */

--- a/packages/player/src/internal/beacon/types.ts
+++ b/packages/player/src/internal/beacon/types.ts
@@ -1,3 +1,4 @@
+import type { MediaProduct } from '../../api/interfaces';
 import type { PlaybackSession } from '../../internal/event-tracking/play-log/playback-session';
 import type { DrmLicenseFetch } from '../../internal/event-tracking/streaming-metrics/drm-license-fetch';
 import type { PlaybackInfoFetch } from '../../internal/event-tracking/streaming-metrics/playback-info-fetch';
@@ -11,6 +12,7 @@ export type BaseEvent = {
     token: string;
     version: string;
   };
+  extras?: MediaProduct['extras'];
   ts: number;
   user: {
     accessToken: string;

--- a/packages/player/src/internal/beacon/worker.ts
+++ b/packages/player/src/internal/beacon/worker.ts
@@ -170,6 +170,7 @@ export function beacon() {
           token: clientId,
           version: data.appVersion,
         },
+        ...('extras' in streamingEvent && { extras: streamingEvent.extras }),
         group: data.type,
         name: streamingEvent.name,
         payload: streamingEvent.payload,

--- a/packages/player/src/internal/event-tracking/play-log/index.ts
+++ b/packages/player/src/internal/event-tracking/play-log/index.ts
@@ -1,7 +1,6 @@
 export { playbackSession, playbackSessionAction } from './playback-session';
 
-import type { MediaProduct } from 'api/interfaces';
-
+import type { MediaProduct } from '../../../api/interfaces';
 import {
   commit as beaconCommit,
   commitOpen as beaconCommitOpen,

--- a/packages/player/src/internal/handlers/set-next.ts
+++ b/packages/player/src/internal/handlers/set-next.ts
@@ -127,6 +127,7 @@ async function _setNext(
       'videoId' in playbackInfo ? playbackInfo.videoId : playbackInfo.trackId,
     ),
     actualQuality: streamInfo.quality,
+    extras: mediaProduct.extras,
     isPostPaywall: getIsPostPaywall(
       playbackInfo.assetPresentation,
       mediaProduct,

--- a/packages/player/src/internal/helpers/get-is-post-paywall.ts
+++ b/packages/player/src/internal/helpers/get-is-post-paywall.ts
@@ -1,5 +1,5 @@
-import type { MediaProduct } from 'api/interfaces';
-import type { AssetPresentation } from 'internal/types';
+import type { MediaProduct } from '../../api/interfaces';
+import type { AssetPresentation } from '../types';
 
 /**
  * Returns a boolean indicating whether the user is in a post-paywall state.

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -361,6 +361,7 @@ export class BasePlayer {
       actualQuality:
         playbackContext.actualAudioQuality ||
         playbackContext.actualVideoQuality,
+      extras: mediaProduct.extras,
       isPostPaywall: getIsPostPaywall(
         playbackContext.actualAssetPresentation,
         mediaProduct,

--- a/packages/player/src/player/index.ts
+++ b/packages/player/src/player/index.ts
@@ -1,5 +1,4 @@
-import type { MediaProduct } from 'api/interfaces';
-
+import type { MediaProduct } from '../api/interfaces';
 import { events } from '../event-bus';
 import type { AudioQuality } from '../internal/types';
 


### PR DESCRIPTION
Also switches some absolute paths to relative (used for types) for consistency.