### PR TITLE
Stop endless upgrade loop when client secret changed

### DIFF
--- a/packages/auth/src/auth/auth.test.ts
+++ b/packages/auth/src/auth/auth.test.ts
@@ -750,18 +750,22 @@ describe.sequential('auth', () => {
 
       await init({
         clientId: 'NEW_CLIENT_ID',
-        clientSecret: 'CLIENT_SECRET',
+        clientSecret: 'NEW_CLIENT_SECRET',
         credentialsStorageKey: 'CREDENTIALS_STORAGE_KEY',
       });
 
       const accessToken = await getCredentials();
 
-      expect(fetchHandling.handleTokenFetch).toHaveBeenCalled();
       expect(storage.saveCredentialsToStorage).toHaveBeenCalled();
       expect(accessToken).toEqual({
         ...fixtures.storageClientCredentials.accessToken,
         clientId: 'NEW_CLIENT_ID',
       });
+
+      // second time should not call the fetch again, upgrade loop was stopped
+      await getCredentials();
+
+      expect(fetchHandling.handleTokenFetch).toHaveBeenCalledTimes(1);
     });
 
     it('token failed to upgrade, throw error', async () => {


### PR DESCRIPTION
In case the secret and client id changed, it was possible to land in an endless loop of upgrading the token because the condition for if we need to upgrade was never changed. This PR updates the `previousClientSecret` in case a successful "upgrade" has happened. (an upgrade in this situation is just a token fetch)