### PR TITLE
Remove version for pnpm/action-setup in the Tidal API workflow

### DIFF
--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -38,7 +38,6 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
           run_install: false
       - name: Install dependencies
         run: |


### PR DESCRIPTION
As it caused:
  Error: Error: Multiple versions of pnpm specified:
    - version 10 in the GitHub Action config with the key "version"
    - version pnpm@10.14.0 in the package.json with the key "packageManager" Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION