### PR TITLE
Player: Remove support for 'demo' product type

### DIFF
--- a/packages/player/src/api/interfaces.ts
+++ b/packages/player/src/api/interfaces.ts
@@ -58,7 +58,7 @@ export type MediaProduct = {
   /** The id of the product to play */
   productId: string;
   /** The type of the product to play */
-  productType: 'demo' | 'track' | 'video';
+  productType: 'track' | 'video';
   /** Optional client-set reference id to handle duplicated in a play queue implementation */
   referenceId?: string;
   /** The id of the source to play, passed along for event tracking */

--- a/packages/player/src/internal/event-tracking/play-log/index.test.ts
+++ b/packages/player/src/internal/event-tracking/play-log/index.test.ts
@@ -10,8 +10,4 @@ describe('mapProductTypeToPlayLogProductType', () => {
   it('returns the correct playlog product type for videos', () => {
     expect(mapProductTypeToPlayLogProductType('video')).to.equal('VIDEO');
   });
-
-  it('returns the correct playlog product type for demos', () => {
-    expect(mapProductTypeToPlayLogProductType('demo')).to.equal('UC');
-  });
 });

--- a/packages/player/src/internal/event-tracking/play-log/index.ts
+++ b/packages/player/src/internal/event-tracking/play-log/index.ts
@@ -14,8 +14,6 @@ export function mapProductTypeToPlayLogProductType(
   productType: MediaProduct['productType'],
 ): PlayLogProductType {
   switch (productType) {
-    case 'demo':
-      return 'UC';
     case 'video':
       return 'VIDEO';
     case 'track':

--- a/packages/player/src/internal/helpers/manifest-parser.ts
+++ b/packages/player/src/internal/helpers/manifest-parser.ts
@@ -83,7 +83,7 @@ export type StreamInfo = {
   streamingSessionId: string;
   trackPeakAmplitude?: number;
   trackReplayGain?: number;
-  type: 'demo' | 'track' | 'video';
+  type: 'track' | 'video';
 };
 
 function streamFormatToCodec(

--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -1,14 +1,8 @@
 import { expect } from 'chai';
 
-import type { MediaProduct } from '../../api/interfaces';
 import { authAndEvents, credentialsProvider } from '../../test-helpers';
-import { mimeTypes } from '../constants';
 
-import {
-  type Options,
-  fetchPlaybackInfo,
-  getDemoPlaybackInfo,
-} from './playback-info-resolver';
+import { fetchPlaybackInfo } from './playback-info-resolver';
 
 describe('playbackInfoResolver', () => {
   authAndEvents(before, after);
@@ -61,52 +55,5 @@ describe('playbackInfoResolver', () => {
     expect(result.assetPresentation).to.equal('FULL');
     expect(result.manifestMimeType).to.not.equal(undefined);
     expect(result.manifest).to.not.equal(undefined);
-  });
-
-  it('gets playback info for demo content', async () => {
-    const { clientId, token } = await credentialsProvider.getCredentials();
-
-    // eslint-disable-next-line no-restricted-syntax
-    const streamingSessionId = `tidal-player-js-test-${Date.now()}`;
-
-    const mediaProduct: MediaProduct = {
-      productId: '1316405',
-      productType: 'demo',
-      sourceId: '',
-      sourceType: '',
-    };
-
-    const options: Options = {
-      accessToken: token,
-      audioQuality: 'LOW',
-      clientId,
-      mediaProduct,
-      prefetch: false,
-      streamingSessionId,
-    };
-
-    const playbackInfo = getDemoPlaybackInfo(options);
-
-    expect(playbackInfo).to.deep.include({
-      assetPresentation: 'FULL',
-      audioMode: 'STEREO',
-      audioQuality: 'LOW',
-
-      manifest: btoa(
-        JSON.stringify({
-          mimeType: mimeTypes.HLS,
-          urls: [
-            `https://fsu.fa.tidal.com/storage/${mediaProduct.productId}.m3u8`,
-          ],
-        }),
-      ),
-      manifestMimeType: mimeTypes.EMU,
-      prefetched: false,
-      streamType: 'ON_DEMAND',
-      streamingSessionId,
-      trackId: mediaProduct.productId,
-    });
-
-    expect(playbackInfo.expires).to.be.a('number');
   });
 });

--- a/packages/player/src/internal/helpers/playback-info-resolver.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.ts
@@ -257,31 +257,6 @@ async function _fetch(options: Options): Promise<PlaybackInfo> {
   };
 }
 
-export function getDemoPlaybackInfo(options: Options): PlaybackInfo {
-  const { mediaProduct, streamingSessionId } = options;
-
-  return {
-    assetPresentation: 'FULL',
-    audioMode: 'STEREO',
-    audioQuality: 'LOW',
-    // eslint-disable-next-line no-restricted-syntax
-    expires: Date.now() + 3600000,
-    manifest: btoa(
-      JSON.stringify({
-        mimeType: mimeTypes.HLS,
-        urls: [
-          `https://fsu.fa.tidal.com/storage/${mediaProduct.productId}.m3u8`,
-        ],
-      }),
-    ),
-    manifestMimeType: mimeTypes.EMU,
-    prefetched: false,
-    streamType: 'ON_DEMAND',
-    streamingSessionId,
-    trackId: mediaProduct.productId,
-  };
-}
-
 export async function fetchPlaybackInfo(options: Options) {
   const { streamingSessionId } = options;
   const events = [];
@@ -294,11 +269,7 @@ export async function fetchPlaybackInfo(options: Options) {
   try {
     let playbackInfo: PlaybackInfo;
 
-    if (options.mediaProduct.productType === 'demo') {
-      playbackInfo = getDemoPlaybackInfo(options);
-    } else {
-      playbackInfo = await _fetch(options);
-    }
+    playbackInfo = await _fetch(options);
 
     if (playbackInfo === undefined) {
       throw new Error('Playback info was fetched, but undefined.');

--- a/packages/player/src/player/index.ts
+++ b/packages/player/src/player/index.ts
@@ -19,7 +19,7 @@ export type PlayerConfig = {
 
 const defaultPlayerConfig: Array<PlayerConfig> = [
   {
-    itemTypes: ['track', 'video', 'demo'],
+    itemTypes: ['track', 'video'],
     player: 'shaka',
     qualities: ['HIGH', 'LOSSLESS', 'LOW', 'HI_RES_LOSSLESS'],
   },
@@ -140,7 +140,7 @@ async function getShakaPlayer() {
 }
 
 export async function getAppropriatePlayer(
-  productType: 'demo' | 'track' | 'video',
+  productType: 'track' | 'video',
   audioQuality: AudioQuality | undefined,
 ) {
   const appropriatePlayers = playerConfig

--- a/packages/player/src/player/shakaPlayer.ts
+++ b/packages/player/src/player/shakaPlayer.ts
@@ -335,35 +335,23 @@ export default class ShakaPlayer extends BasePlayer {
   }
 
   /**
-   * Playback of media product type demo needs to be done with
-   * useNativeHlsForFairPlay and preferNativeHls set to false.
+   * Playback of media product type demo needed to be done with
+   * useNativeHlsForFairPlay and preferNativeHls set to false, but
+   * we don't support `demo` anymore.
    */
-  async #configureHlsForPlayback(
-    instance: shaka.Player | undefined,
-    mediaProduct: MediaProduct,
-  ) {
+  async #configureHlsForPlayback(instance: shaka.Player | undefined) {
     const isFairPlaySupported =
       await shaka.util.FairPlayUtils.isFairPlaySupported();
 
     if (isFairPlaySupported && instance) {
-      if (
-        instance.getConfiguration().streaming.preferNativeHls !==
-        (mediaProduct.productType !== 'demo')
-      ) {
-        instance.configure(
-          'streaming.preferNativeHls',
-          mediaProduct.productType !== 'demo',
-        );
+      if (instance.getConfiguration().streaming.preferNativeHls !== true) {
+        instance.configure('streaming.preferNativeHls', true);
       }
 
       if (
-        instance.getConfiguration().streaming.useNativeHlsForFairPlay !==
-        (mediaProduct.productType !== 'demo')
+        instance.getConfiguration().streaming.useNativeHlsForFairPlay !== true
       ) {
-        instance.configure(
-          'streaming.useNativeHlsForFairPlay',
-          mediaProduct.productType !== 'demo',
-        );
+        instance.configure('streaming.useNativeHlsForFairPlay', true);
       }
 
       // await instance.release();
@@ -841,10 +829,7 @@ export default class ShakaPlayer extends BasePlayer {
     await this.reset();
     this.#isReset = false;
 
-    await this.#configureHlsForPlayback(
-      this.shakaInstance,
-      payload.mediaProduct,
-    );
+    await this.#configureHlsForPlayback(this.shakaInstance);
 
     await ensureVideoElementsMounted();
 


### PR DESCRIPTION
- Updated MediaProduct and StreamInfo types to exclude 'demo'.
- Removed demo-related tests and playback info functions.
- Adjusted player configuration and playback logic to reflect the removal of 'demo' support.
- Ensured all references to 'demo' are eliminated from event tracking and playback resolution.