### PR TITLE
Player: Update getOutputDevices function type to return an array of OutputDevice

### DIFF
--- a/packages/player/src/internal/handlers/get-output-devices.ts
+++ b/packages/player/src/internal/handlers/get-output-devices.ts
@@ -1,9 +1,9 @@
+import type { OutputDevice } from '../../internal/output-devices';
+
 /**
  * Get the available output devices.
- *
- * @returns { Set<OutputDevice>}
  */
-export async function getOutputDevices() {
+export async function getOutputDevices(): Promise<Array<OutputDevice>> {
   const { outputDevices } = await import('../../internal/output-devices');
 
   return [...outputDevices.outputDevices];


### PR DESCRIPTION
- Changed the return type of getOutputDevices from Set to Promise<Array<OutputDevice>>.
- Added import statement for OutputDevice type to ensure type safety.

This fixes an issue where the generated types for the package are broken (in `index.d.ts`), as they included this line: 
`import { OutputDevice as OutputDevice_2 } from '../..';` (with an unresolved import)