### PR TITLE
Enhance commit message formatting in Tidal API workflow

### DIFF
--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -144,6 +144,7 @@ jobs:
 
           # Create commit message with changes in both generated file and spec
           commit_body="Changes in generated file:\n${{ steps.check_for_changes.outputs.CHANGES_IN_GENERATED }}\n\nChanges in spec file:\n${{ steps.check_for_changes.outputs.CHANGES_IN_SPEC }}"
+          commit_body=$(echo -e "$commit_body")
 
           git add ${{ env.API_FOLDER }}/${{ env.GENERATED_FILE }} ${{ env.API_FOLDER }}/${{ env.SPEC_FILE }}
 


### PR DESCRIPTION
Added a command to format the commit body for better readability, ensuring changes in both the generated file and spec file are clearly presented. (was printing '\n' before)