### PR TITLE
Fix incorrect delayed seek in `nativeplayer`

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2025-12-09
+
+### Changed
+
+- Fix NativePlayer incorrect seek issue (#452)
+
 ## [0.11.1] - 2025-12-03
 
 ### Changed

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/player",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Player logic for TIDAL",
   "type": "module",
   "exports": {

--- a/packages/player/src/player/nativePlayer.ts
+++ b/packages/player/src/player/nativePlayer.ts
@@ -315,6 +315,7 @@ export default class NativePlayer extends BasePlayer {
         // Once the player becomes active, we need to make sure that
         // the streaming session has not changed, else we will seek the
         // wrong track!
+        // See: https://github.com/tidal-music/tidal-sdk-web/pull/452
         if (this.currentStreamingSessionId === streamInfo.streamingSessionId) {
           await this.seek(assetPosition);
           this.currentTime = assetPosition;


### PR DESCRIPTION
Claude's summary of the issue and fix, which I agree with:

> When load() is called with a non-zero assetPosition, it starts an unawaited async IIFE that waits for the player to become 'active' before seeking:
> 
```
   (async () => {
     await this.mediaStateChange('active');
     await this.seek(assetPosition);
     this.currentTime = assetPosition;
   })().catch(console.error);
```
> 
>   This async operation can execute after a subsequent load has already started on a different track:
> 
>   1. Client reloads, calls load(trackA, position=30) to restore state
>   2. Async IIFE starts waiting for 'active' state
>   3. User loads trackB with position=0 before trackA plays
>   4. reset() sets state to IDLE, trackB loads
>   5. User clicks play → state becomes 'active'
>   6. The old async IIFE wakes up and seeks to position 30 on trackB!
> 
>   The Fix
> 
>   I added a streaming session check inside the async IIFE to ensure it only seeks if the streaming session hasn't changed:
> 
```
   const targetStreamingSessionId = streamInfo.streamingSessionId;
   (async () => {
     await this.mediaStateChange('active');
     // Only seek if this is still the current streaming session
     if (this.currentStreamingSessionId === targetStreamingSessionId) {
       await this.seek(assetPosition);
       this.currentTime = assetPosition;
     }
   })().catch(console.error);
```