### PR TITLE
refactor(player): deprecate 'HI_RES' audio quality and enhance manifest parser

### DIFF
--- a/packages/player/src/internal/helpers/manifest-parser.ts
+++ b/packages/player/src/internal/helpers/manifest-parser.ts
@@ -106,12 +106,17 @@ function streamFormatToCodec(
 
 /**
  * Find bit depth in a DASH manifest (from last int in id attribute of Representation, e.g. id="FLAC,44100,16")
+ * Returns undefined for ids without commas like "HEAACV1" or "AACLC".
  */
 function dashFindBitDepth(manifest: string): number | undefined {
   const repMatch = /<Representation[^>]*id="([^"]+)"/.exec(manifest);
   if (repMatch) {
     const id = repMatch[1];
-    const numbers = id?.match(/\d+/g);
+    // Only extract bit depth from comma-separated formats like "FLAC,44100,16"
+    if (!id?.includes(',')) {
+      return undefined;
+    }
+    const numbers = id.match(/\d+/g);
     if (numbers && numbers.length > 0) {
       return Number(numbers[numbers.length - 1]);
     }

--- a/packages/player/src/internal/types.ts
+++ b/packages/player/src/internal/types.ts
@@ -1,11 +1,18 @@
 export type StreamType = 'LIVE' | 'ON_DEMAND';
 export type AssetPresentation = 'FULL' | 'PREVIEW';
 export type AudioMode = 'DOLBY_ATMOS' | 'SONY_360RA' | 'STEREO';
+
+/**
+ * @deprecated Use 'HI_RES_LOSSLESS' instead of 'HI_RES'.
+ */
+type DeprecatedAudioQuality = 'HI_RES';
+
 export type AudioQuality =
-  | 'HI_RES'
   | 'HI_RES_LOSSLESS'
   | 'HIGH'
   | 'LOSSLESS'
-  | 'LOW';
+  | 'LOW'
+  | DeprecatedAudioQuality;
+
 export type VideoQuality = 'AUDIO_ONLY' | 'HIGH' | 'LOW' | 'MEDIUM';
 export type Codec = 'aac' | 'flac' | 'mp3';


### PR DESCRIPTION
- Mark 'HI_RES' as deprecated in favor of 'HI_RES_LOSSLESS' in types.ts
- Improve dashFindBitDepth function to handle comma-separated formats more robustly