### PR TITLE
use playbackinfo for replaygain

### DIFF
--- a/packages/player/src/internal/helpers/normalize-volume.ts
+++ b/packages/player/src/internal/helpers/normalize-volume.ts
@@ -1,5 +1,4 @@
-export function normalizeVolume(replayGain: number): number {
-  const peak = 1;
+export function normalizeVolume(replayGain: number, peak = 1): number {
   const preAmp = 4;
 
   return Math.min(Math.pow(10, (preAmp + replayGain) / 20), 1 / peak);

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -142,12 +142,22 @@ export class BasePlayer {
 
     let adjustedVolume = level;
 
-    if (loudnessNormalizationMode === 'ALBUM' && streamInfo.albumReplayGain) {
-      adjustedVolume *= normalizeVolume(streamInfo.albumReplayGain);
-    }
-
-    if (loudnessNormalizationMode === 'TRACK' && streamInfo.trackReplayGain) {
-      adjustedVolume *= normalizeVolume(streamInfo.trackReplayGain);
+    if (
+      loudnessNormalizationMode === 'ALBUM' &&
+      streamInfo.albumReplayGain !== undefined
+    ) {
+      adjustedVolume *= normalizeVolume(
+        streamInfo.albumReplayGain,
+        streamInfo.albumPeakAmplitude,
+      );
+    } else if (
+      loudnessNormalizationMode === 'TRACK' &&
+      streamInfo.trackReplayGain !== undefined
+    ) {
+      adjustedVolume *= normalizeVolume(
+        streamInfo.trackReplayGain,
+        streamInfo.trackPeakAmplitude,
+      );
     }
 
     this.debugLog(


### PR DESCRIPTION
Change normalizeVolume to be able to use the real values for replaygain instead of hard coding them.