### PR TITLE
Release version 0.13.0 with legacy API support

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-02-10
+
+### Changed
+
+- Expose `setLegacyApiUrl` so both legacy and current API can be overridden
+
 ## [0.12.0] - 2026-01-26
 
 ### Changed

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/player",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Player logic for TIDAL",
   "type": "module",
   "exports": {

--- a/packages/player/src/api/index.ts
+++ b/packages/player/src/api/index.ts
@@ -20,6 +20,7 @@ export { setApiUrl } from '../internal/handlers/set-api-url';
 export { setAudioAdaptiveBitrateStreaming } from '../internal/handlers/set-audio-adaptive-bitrate-streaming';
 export { setCredentialsProvider } from '../internal/handlers/set-credentials-provider';
 export { setEventSender } from '../internal/handlers/set-event-sender';
+export { setLegacyApiUrl } from '../internal/handlers/set-legacy-api-url';
 
 export { setLoudnessNormalizationMode } from '../internal/handlers/set-loudness-normalization-mode';
 export { setNext } from '../internal/handlers/set-next';

--- a/packages/player/src/config.ts
+++ b/packages/player/src/config.ts
@@ -6,16 +6,18 @@ type Config = {
   audioAdaptiveBitrateStreaming: boolean;
   desiredVolumeLevel: number;
   gatherEvents: boolean;
+  legacyApiUrl: string;
   loudnessNormalizationMode: LoudnessNormalizationMode;
   outputDevicesEnabled: boolean;
   streamingWifiAudioQuality: AudioQuality;
 };
 
 let state = Object.freeze({
-  apiUrl: 'https://api.tidal.com/v1',
+  apiUrl: 'https://openapi.tidal.com/v2/',
   audioAdaptiveBitrateStreaming: true,
   desiredVolumeLevel: 1,
   gatherEvents: true,
+  legacyApiUrl: 'https://api.tidal.com/v1',
   loudnessNormalizationMode: 'ALBUM',
   outputDevicesEnabled: false,
   streamingWifiAudioQuality: 'LOW',

--- a/packages/player/src/internal/handlers/set-api-url.ts
+++ b/packages/player/src/internal/handlers/set-api-url.ts
@@ -1,9 +1,9 @@
 import * as Config from '../../config';
 
 /**
- * Configure the module to use another URL for the API than the normal one.
+ * Configure the module to use a custom URL for the OpenAPI API (e.g. track manifests).
  *
- * @param {string} apiUrl
+ * @param apiUrl - URL for the main (OpenAPI) API.
  */
 export function setApiUrl(apiUrl: string) {
   // eslint-disable-next-line no-useless-catch
@@ -13,7 +13,5 @@ export function setApiUrl(apiUrl: string) {
     throw e;
   }
 
-  Config.update({
-    apiUrl,
-  });
+  Config.update({ apiUrl });
 }

--- a/packages/player/src/internal/handlers/set-legacy-api-url.test.ts
+++ b/packages/player/src/internal/handlers/set-legacy-api-url.test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+
+import * as Config from '../../config';
+
+import { setLegacyApiUrl } from './set-legacy-api-url';
+
+describe('setLegacyApiUrl', () => {
+  it('sets the legacy url in config', () => {
+    setLegacyApiUrl('https://legacy-api.example.com/v1');
+
+    expect(Config.get('legacyApiUrl')).to.equal(
+      'https://legacy-api.example.com/v1',
+    );
+  });
+
+  it('fails if not a url', () => {
+    expect(() => setLegacyApiUrl('not-a-url')).to.throw(
+      "Failed to construct 'URL': Invalid URL",
+    );
+  });
+});

--- a/packages/player/src/internal/handlers/set-legacy-api-url.ts
+++ b/packages/player/src/internal/handlers/set-legacy-api-url.ts
@@ -1,0 +1,17 @@
+import * as Config from '../../config';
+
+/**
+ * Configure the module to use a custom URL for legacy API endpoints (e.g. playbackinfo, rt/connect).
+ *
+ * @param legacyApiUrl - URL for the legacy API.
+ */
+export function setLegacyApiUrl(legacyApiUrl: string) {
+  // eslint-disable-next-line no-useless-catch
+  try {
+    new URL(legacyApiUrl);
+  } catch (e) {
+    throw e;
+  }
+
+  Config.update({ legacyApiUrl });
+}

--- a/packages/player/src/internal/helpers/playback-info-resolver.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.ts
@@ -167,9 +167,9 @@ async function _fetchLegacyPlaybackInfo(
     streamingSessionId,
   } = options;
 
-  const apiUrl = Config.get('apiUrl');
+  const legacyApiUrl = Config.get('legacyApiUrl');
   const url = new URL(
-    `${apiUrl}/${mediaProduct.productType}s/${mediaProduct.productId}/playbackinfo`,
+    `${legacyApiUrl}/${mediaProduct.productType}s/${mediaProduct.productId}/playbackinfo`,
   );
   const searchParams = url.searchParams as URLSearchParamsCustomSetters<
     'assetpresentation' | 'audioquality' | 'playbackmode' | 'videoquality'
@@ -332,6 +332,7 @@ async function _fetchTrackManifest(options: Options): Promise<PlaybackInfo> {
   // TODO: consider saving the API client for reuse
   const apiClient = createAPIClient(
     credentialsProviderStore.credentialsProvider,
+    Config.get('apiUrl'),
   );
 
   const {

--- a/packages/player/src/internal/services/pushkin.ts
+++ b/packages/player/src/internal/services/pushkin.ts
@@ -49,8 +49,8 @@ let pushkin: Pushkin | undefined;
 // Only exported for testing.
 // eslint-disable-next-line disable-autofix/jsdoc/require-jsdoc
 export async function fetchWebSocketURL(accessToken: string) {
-  const apiUrl = Config.get('apiUrl');
-  const response = await fetch(apiUrl + '/rt/connect', {
+  const legacyApiUrl = Config.get('legacyApiUrl');
+  const response = await fetch(legacyApiUrl + '/rt/connect', {
     headers: new Headers({
       Authorization: 'Bearer ' + accessToken,
       'Content-Type': 'application/json',


### PR DESCRIPTION
- Exposed `setLegacyApiUrl` to allow configuration of the legacy API URL.
- Updated configuration to include `legacyApiUrl` for backward compatibility.
- Modified playback info and WebSocket connection to utilize the legacy API URL when set.
- Added tests for `setLegacyApiUrl` to ensure proper functionality and error handling.