### PR TITLE
Update release workflow and increment API version to 0.8.1

### DIFF
--- a/.github/workflows/release-to-npm.yml
+++ b/.github/workflows/release-to-npm.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,5 +15,3 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - run: pnpm publish --recursive --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
- Added permissions for OIDC and content access in the GitHub Actions workflow for npm releases.
- Incremented the API package version from 0.8.0 to 0.8.1.