### PR TITLE
Remove deprecated README files

### DIFF
--- a/packages/catalogue/README.md
+++ b/packages/catalogue/README.md
@@ -1,4 +1,0 @@
-# TIDAL Catalogue
-
-## Deprecated
-Please use the [API package](../api) instead

--- a/packages/playlist/README.md
+++ b/packages/playlist/README.md
@@ -1,5 +1,0 @@
-# TIDAL Playlist
-
-## Deprecated
-Please use the [API package](../api) instead
-

--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -1,5 +1,0 @@
-# TIDAL Search
-
-## Deprecated
-Please use the [API package](../api) instead
-

--- a/packages/user/README.md
+++ b/packages/user/README.md
@@ -1,4 +1,0 @@
-# TIDAL User
-
-## Deprecated
-Please use the [API package](../api) instead


### PR DESCRIPTION
for TIDAL Catalogue, Playlist, Search, and User packages, directing users to the API package instead.