### PR TITLE
feat(player): use videoManifests API for video playback

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-04-10
+
+### Changed
+
+- Use new `videoManifests` API for video playback instead of legacy playbackinfo endpoint
+- Shaka player updated to: 5.0.9
+
 ## [0.15.0] - 2026-03-03
 
 ### Changed

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/player",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Player logic for TIDAL",
   "type": "module",
   "exports": {

--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -109,6 +109,42 @@ describe('playbackInfoResolver', () => {
     ).to.be.greaterThan(1);
   });
 
+  it('fetches playback info via new videoManifests API for video products', async () => {
+    const { clientId, token } = await credentialsProvider.getCredentials();
+
+    if (!token) {
+      throw new Error('No access token, cannot fulfill test.');
+    }
+
+    const result = await fetchPlaybackInfo({
+      accessToken: token,
+      audioAdaptiveBitrateStreaming: true,
+      audioQuality: 'HIGH',
+      clientId,
+      mediaProduct: {
+        productId: '75623239',
+        productType: 'video',
+        sourceId: '',
+        sourceType: '',
+      },
+      playerType: 'shaka',
+      prefetch: false,
+      // eslint-disable-next-line no-restricted-syntax
+      streamingSessionId: 'tidal-player-js-test-' + Date.now(),
+    });
+
+    expect(result.assetPresentation).to.not.equal(undefined);
+    expect(result.manifestMimeType).to.not.equal(undefined);
+    expect(result.manifest).to.not.equal(undefined);
+
+    expect('videoId' in result).to.equal(true);
+    if ('videoId' in result) {
+      expect(result.videoId).to.equal(75623239);
+      expect(result.videoQuality).to.equal('HIGH');
+      expect(result.streamType).to.equal('ON_DEMAND');
+    }
+  });
+
   it('fetches playback info with ABR disabled (single quality)', async () => {
     const { clientId, token } = await credentialsProvider.getCredentials();
 

--- a/packages/player/src/internal/helpers/playback-info-resolver.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.ts
@@ -444,6 +444,77 @@ async function _fetchTrackManifest(options: Options): Promise<PlaybackInfo> {
 }
 
 /**
+ * Fetches the video manifest for a given media product using the API client.
+ * Retries on 5xx and 429 errors with exponential backoff.
+ */
+async function _fetchVideoManifest(options: Options): Promise<PlaybackInfo> {
+  const apiClient = createAPIClient(
+    credentialsProviderStore.credentialsProvider,
+    Config.get('apiUrl'),
+  );
+
+  const { mediaProduct, prefetch, streamingSessionId } = options;
+  const videoId = mediaProduct.productId;
+
+  let response;
+  try {
+    response = await withRetries(
+      () =>
+        apiClient.GET('/videoManifests/{id}', {
+          params: {
+            headers: {
+              'x-playback-session-id': streamingSessionId,
+            },
+            path: {
+              id: videoId,
+            },
+            query: {
+              uriScheme: 'DATA',
+              usage: 'PLAYBACK',
+            },
+          },
+        }),
+      {
+        baseDelayMs: TRACK_MANIFEST_BASE_DELAY_MS,
+        maxRetries: TRACK_MANIFEST_MAX_RETRIES,
+        shouldRetry: res =>
+          Boolean(res.error) && isRetryableStatus(res.response.status),
+      },
+    );
+  } catch {
+    throw new PlayerError('PENetwork', 'NPBI0');
+  }
+
+  if (response.error) {
+    throw new PlayerError(getErrorId(response.response.status, 0), 'NPBI0');
+  }
+
+  const parsed = parseDataUrl(response.data?.data.attributes?.link?.href);
+
+  const manifest = parsed?.manifest;
+  const manifestMimeType = parsed?.manifestMimeType;
+
+  if (!manifest || !manifestMimeType) {
+    throw new PlayerError('EUnexpected', 'B9999');
+  }
+
+  return {
+    assetPresentation:
+      response.data?.data.attributes?.videoPresentation ?? 'PREVIEW',
+    // eslint-disable-next-line no-restricted-syntax
+    expires: Date.now() + MANIFEST_EXPIRATION_MS,
+    manifest,
+    manifestMimeType,
+    prefetched: prefetch,
+    previewReason: response.data?.data.attributes?.previewReason,
+    streamType: 'ON_DEMAND',
+    streamingSessionId,
+    videoId: response.data?.data.id ? Number(response.data.data.id) : 0,
+    videoQuality: 'HIGH',
+  };
+}
+
+/**
  * Fetches playback information for a media product.
  *
  * @param options - The options for fetching playback info including media product, audio quality, and streaming session ID.
@@ -461,12 +532,10 @@ export async function fetchPlaybackInfo(options: Options) {
   try {
     let playbackInfo: PlaybackInfo;
 
-    if (
-      options.mediaProduct.productType === 'video' ||
-      options.playerType === 'native'
-    ) {
-      // Use old API for videos and Native Player track playback
+    if (options.playerType === 'native') {
       playbackInfo = await _fetchLegacyPlaybackInfo(options);
+    } else if (options.mediaProduct.productType === 'video') {
+      playbackInfo = await _fetchVideoManifest(options);
     } else {
       playbackInfo = await _fetchTrackManifest(options);
     }


### PR DESCRIPTION
## Summary

- Adds `_fetchVideoManifest` that calls the new `GET /videoManifests/{id}` endpoint for video playback, replacing the legacy playbackinfo API.
- Updates routing in `fetchPlaybackInfo` so videos use the new API while the native player path still uses the legacy endpoint.
- Bumps player to **0.16.0** with changelog entry.

## Test plan

- [ ] Verify video playback works end-to-end with the new manifest endpoint.
- [ ] Verify track playback (shaka) is unaffected.
- [ ] Verify native player still uses the legacy API for both tracks and videos.
- [ ] Run `playback-info-resolver.test.ts` — includes new test for video manifest fetch.

Made with [Cursor](https://cursor.com)