### PR TITLE
Support share code for track manifests

### DIFF
--- a/packages/player/src/api/interfaces.ts
+++ b/packages/player/src/api/interfaces.ts
@@ -64,6 +64,8 @@ export type MediaProduct = {
   productType: 'track' | 'video';
   /** Optional client-set reference id to handle duplicated in a play queue implementation */
   referenceId?: string;
+  /** Share code that grants access to UNLISTED resources */
+  shareCode?: string;
   /** The id of the source to play, passed along for event tracking */
   sourceId: string;
   /** The type of the source to play, passed along for event tracking */

--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -25,6 +25,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'native',
       prefetch: false,
+      // eslint-disable-next-line no-restricted-syntax
       streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
@@ -54,6 +55,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'native',
       prefetch: false,
+      // eslint-disable-next-line no-restricted-syntax
       streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
@@ -83,6 +85,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'shaka',
       prefetch: false,
+      // eslint-disable-next-line no-restricted-syntax
       streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
@@ -126,6 +129,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'shaka',
       prefetch: false,
+      // eslint-disable-next-line no-restricted-syntax
       streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
@@ -162,6 +166,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'shaka',
       prefetch: false,
+      // eslint-disable-next-line no-restricted-syntax
       streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
@@ -191,6 +196,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'shaka',
       prefetch: false,
+      // eslint-disable-next-line no-restricted-syntax
       streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 

--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -25,8 +25,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'native',
       prefetch: false,
-      // eslint-disable-next-line no-restricted-syntax
-      streamingSessionId: 'tidal-player-js-test-' + Date.now(),
+      streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
     expect(result.assetPresentation).to.equal('PREVIEW');
@@ -55,8 +54,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'native',
       prefetch: false,
-      // eslint-disable-next-line no-restricted-syntax
-      streamingSessionId: 'tidal-player-js-test-' + Date.now(),
+      streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
     expect(result.assetPresentation).to.equal('FULL');
@@ -85,8 +83,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'shaka',
       prefetch: false,
-      // eslint-disable-next-line no-restricted-syntax
-      streamingSessionId: 'tidal-player-js-test-' + Date.now(),
+      streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
     expect(result.assetPresentation).to.equal('FULL');
@@ -129,8 +126,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'shaka',
       prefetch: false,
-      // eslint-disable-next-line no-restricted-syntax
-      streamingSessionId: 'tidal-player-js-test-' + Date.now(),
+      streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
     expect(result.assetPresentation).to.not.equal(undefined);
@@ -143,6 +139,35 @@ describe('playbackInfoResolver', () => {
       expect(result.videoQuality).to.equal('HIGH');
       expect(result.streamType).to.equal('ON_DEMAND');
     }
+  });
+
+  it('fetches track manifest with shareCode provided', async () => {
+    const { clientId, token } = await credentialsProvider.getCredentials();
+
+    if (!token) {
+      throw new Error('No access token, cannot fulfill test.');
+    }
+
+    const result = await fetchPlaybackInfo({
+      accessToken: token,
+      audioAdaptiveBitrateStreaming: true,
+      audioQuality: 'LOSSLESS',
+      clientId,
+      mediaProduct: {
+        productId: '1316405',
+        productType: 'track',
+        shareCode: 'abc123',
+        sourceId: '',
+        sourceType: '',
+      },
+      playerType: 'shaka',
+      prefetch: false,
+      streamingSessionId: `tidal-player-js-test-${Date.now()}`,
+    });
+
+    expect(result.assetPresentation).to.equal('FULL');
+    expect(result.manifestMimeType).to.not.equal(undefined);
+    expect(result.manifest).to.not.equal(undefined);
   });
 
   it('fetches playback info with ABR disabled (single quality)', async () => {
@@ -166,8 +191,7 @@ describe('playbackInfoResolver', () => {
       },
       playerType: 'shaka',
       prefetch: false,
-      // eslint-disable-next-line no-restricted-syntax
-      streamingSessionId: 'tidal-player-js-test-' + Date.now(),
+      streamingSessionId: `tidal-player-js-test-${Date.now()}`,
     });
 
     expect(result.assetPresentation).to.equal('FULL');

--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -158,9 +158,9 @@ describe('playbackInfoResolver', () => {
       audioQuality: 'LOSSLESS',
       clientId,
       mediaProduct: {
-        productId: '1316405',
+        productId: '518309787',
         productType: 'track',
-        shareCode: 'abc123',
+        shareCode: '36d1002d-e674-48f6-bd57-626b4eb453b6',
         sourceId: '',
         sourceType: '',
       },

--- a/packages/player/src/internal/helpers/playback-info-resolver.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.ts
@@ -360,7 +360,7 @@ async function _fetchTrackManifest(options: Options): Promise<PlaybackInfo> {
     prefetch,
     streamingSessionId,
   } = options;
-  const trackId = mediaProduct.productId;
+  const { productId: trackId, shareCode } = mediaProduct;
 
   const isFairPlaySupported = await shaka.drm.FairPlay.isFairPlaySupported();
 
@@ -380,6 +380,7 @@ async function _fetchTrackManifest(options: Options): Promise<PlaybackInfo> {
               adaptive: audioAdaptiveBitrateStreaming,
               formats: audioQualityToFormats(audioQuality),
               manifestType: isFairPlaySupported ? 'HLS' : 'MPEG_DASH',
+              shareCode,
               uriScheme: 'DATA',
               usage: 'PLAYBACK',
             },


### PR DESCRIPTION
This PR adds passing through the shareCode param for track manifests.

Testing:
* Automated test added