### PR TITLE
feat(player): serve dev at https://dev.tidal.com:5173

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Ensure Cypress binary is installed
         working-directory: packages/player
         run: pnpm exec cypress install
+      - name: Map dev.tidal.com to localhost
+        # Player dev server runs at https://dev.tidal.com:5173; see README.
+        run: echo "127.0.0.1 dev.tidal.com" | sudo tee -a /etc/hosts
       - name: Prepare test user for player tests
         id: json
         env:
@@ -58,7 +61,9 @@ jobs:
           install: false
           browser: chrome
           start: pnpm --dir packages/player/ dev
-          wait-on: 'http://localhost:5173/demo/test-case-1.html'
+          # tcp: avoids strict-SSL validation against the locally-generated
+          # cert; Chromium ignores cert errors via cypress.config.js.
+          wait-on: 'tcp:dev.tidal.com:5173'
           command: pnpm --dir packages/player/ internal:cypress:run
       - name: Save Cypress binary cache
         if: always()

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -57,13 +57,15 @@ jobs:
         uses: cypress-io/github-action@783cb3f07983868532cabaedaa1e6c00ff4786a8 # v7.1.9
         env:
           CYPRESS_TEST_USER: ${{ steps.json.outputs.encoded }}
+          # wait-on uses Node's https stack and would otherwise reject the
+          # locally-generated cert; Chromium itself ignores cert errors via
+          # cypress.config.js.
+          NODE_TLS_REJECT_UNAUTHORIZED: '0'
         with:
           install: false
           browser: chrome
           start: pnpm --dir packages/player/ dev
-          # tcp: avoids strict-SSL validation against the locally-generated
-          # cert; Chromium ignores cert errors via cypress.config.js.
-          wait-on: 'tcp:dev.tidal.com:5173'
+          wait-on: 'https://dev.tidal.com:5173/demo/test-case-1.html'
           command: pnpm --dir packages/player/ internal:cypress:run
       - name: Save Cypress binary cache
         if: always()

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -18,6 +18,28 @@ The dist/ folder contains the latest built version of the code in src/.
 
 - [NPM/Node.js](https://nodejs.org/en/)
 
+### Local HTTPS for the demo / Cypress
+
+The dev server runs at `https://dev.tidal.com:5173`. Cert generation and trust
+are handled by [`vite-plugin-mkcert`](https://www.npmjs.com/package/vite-plugin-mkcert);
+nothing cert-related is checked in.
+
+One-time setup per machine:
+
+1. Add a hosts entry so `dev.tidal.com` resolves locally:
+
+   ```sh
+   echo "127.0.0.1 dev.tidal.com" | sudo tee -a /etc/hosts
+   ```
+
+2. Run `pnpm dev` once. The first run will prompt for `sudo` so mkcert can
+   install its local root CA into the system trust store. Subsequent runs are
+   silent.
+
+Behind a corporate proxy, prefix the command with `HTTPS_PROXY=...` so mkcert
+can download its binary. To wipe and re-trust:
+`mkcert -uninstall && rm -rf "$(mkcert -CAROOT)"`.
+
 ## Building
 
 Building is done with Vite.
@@ -27,6 +49,9 @@ Building is done with Vite.
 ## Testing
 
 `pnpm test`. You need a `.env` file containing `TEST_USER="base64string"` before running. base64string is base 64 encoded stringified JS object containing oAuthAccessToken, oAuthRefreshToken, oAuthExpirationDate and clientId.
+
+Cypress E2E specs target `https://dev.tidal.com:5173`, so the one-time setup
+above is also a prerequisite for `pnpm cypress:open` / `pnpm cypress:run`.
 
 ### Linking
 

--- a/packages/player/cypress.config.js
+++ b/packages/player/cypress.config.js
@@ -2,7 +2,19 @@ import { defineConfig } from 'cypress';
 
 const config = defineConfig({
   e2e: {
-    baseUrl: 'http://localhost:5173',
+    baseUrl: 'https://dev.tidal.com:5173',
+    setupNodeEvents(on) {
+      // The dev server uses a locally-trusted mkcert certificate for
+      // dev.tidal.com. Headless Chromium in CI does not have the mkcert
+      // root CA in its trust store, so accept the cert unconditionally.
+      // (Local Cypress runs against a CA-trusted cert ignore this no-op.)
+      on('before:browser:launch', (browser, launchOptions) => {
+        if (browser.family === 'chromium') {
+          launchOptions.args.push('--ignore-certificate-errors');
+        }
+        return launchOptions;
+      });
+    },
     specPattern: ['cypress/e2e/**/*.cy.{js,jsx,ts,tsx}'],
     supportFile: false,
   },

--- a/packages/player/cypress/e2e/play-log/case-1.cy.ts
+++ b/packages/player/cypress/e2e/play-log/case-1.cy.ts
@@ -8,7 +8,7 @@ it('Client Test Case 1', () => {
   Cypress.env('credentials', credentials);
 
   // Load test case that logins in and plays a track
-  cy.visit('http://localhost:5173/demo/test-case-1.html', {
+  cy.visit('/demo/test-case-1.html', {
     onBeforeLoad (win) {
       // Clear IndexedDB to prevent cached data from previous tests
       win.indexedDB.deleteDatabase('EventProducerDB');

--- a/packages/player/cypress/e2e/play-log/case-2.cy.ts
+++ b/packages/player/cypress/e2e/play-log/case-2.cy.ts
@@ -8,7 +8,7 @@ it('Client Test Case 2', () => {
   Cypress.env('credentials', credentials);
 
   // Load test case that logins in and plays a track
-  cy.visit('http://localhost:5173/demo/test-case-2.html', {
+  cy.visit('/demo/test-case-2.html', {
     onBeforeLoad (win) {
       // Clear IndexedDB to prevent cached data from previous tests
       win.indexedDB.deleteDatabase('EventProducerDB');

--- a/packages/player/cypress/e2e/play-log/case-gapless.cy.ts
+++ b/packages/player/cypress/e2e/play-log/case-gapless.cy.ts
@@ -8,7 +8,7 @@ it.skip('Gapless Playback Test - Pink Floyd Album Transition', () => {
   Cypress.env('credentials', credentials);
 
   // Load test case that tests gapless transition between two consecutive album tracks
-  cy.visit('http://localhost:5173/demo/test-case-gapless.html', {
+  cy.visit('/demo/test-case-gapless.html', {
     onBeforeLoad (win) {
       // Clear IndexedDB to prevent cached data from previous tests
       win.indexedDB.deleteDatabase('EventProducerDB');

--- a/packages/player/cypress/helpers.ts
+++ b/packages/player/cypress/helpers.ts
@@ -2,5 +2,5 @@ export const SDK_BATCH_INTERVAL = 30_000;
 
 export const INTERCEPT_OPTIONS = {
   method: 'POST',
-  url: 'http://localhost:5173/fakeeventurl',
+  url: '**/fakeeventurl',
 };

--- a/packages/player/demo/helpers.js
+++ b/packages/player/demo/helpers.js
@@ -68,9 +68,9 @@ export async function login() {
       osName: 'Some OS',
     },
     // URI identifying the TL Consumer ingest endpoint.
-    tlConsumerUri: 'http://localhost:5173/fakeeventurl',
+    tlConsumerUri: `${window.location.origin}/fakeeventurl`,
     // URI for unauthorized event batches.
-    tlPublicConsumerUri: 'http://localhost:5173/fakeeventurl',
+    tlPublicConsumerUri: `${window.location.origin}/fakeeventurl`,
   });
 
   Player.setCredentialsProvider(auth.credentialsProvider);

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -79,6 +79,7 @@
     "typescript": "6.0.3",
     "vite": "8.0.10",
     "vite-plugin-dts": "4.5.4",
+    "vite-plugin-mkcert": "2.0.0",
     "vite-plugin-package-version": "1.1.0"
   }
 }

--- a/packages/player/src/internal/handlers/load.ts
+++ b/packages/player/src/internal/handlers/load.ts
@@ -150,7 +150,10 @@ export async function load(
       events.dispatchError(e);
     }
 
-    if (document.location.href.includes('localhost')) {
+    if (
+      document.location.hostname === 'localhost' ||
+      document.location.hostname === 'dev.tidal.com'
+    ) {
       console.error(e);
     }
   }

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -213,7 +213,8 @@ export class BasePlayer {
   // Implements
   debugLog(...args: Array<unknown>) {
     if (
-      document.location.href.includes('localhost') &&
+      (document.location.hostname === 'localhost' ||
+        document.location.hostname === 'dev.tidal.com') &&
       document.location.hash.includes('debug')
     ) {
       console.debug(

--- a/packages/player/vite.config.ts
+++ b/packages/player/vite.config.ts
@@ -1,7 +1,14 @@
 import { loadEnv } from 'vite';
 import dts from 'vite-plugin-dts';
+import mkcert from 'vite-plugin-mkcert';
 import version from 'vite-plugin-package-version';
 import { defineConfig } from 'vitest/config';
+
+// Dev server runs at https://dev.tidal.com:5173. Requires
+// `127.0.0.1 dev.tidal.com` in /etc/hosts; vite-plugin-mkcert installs a
+// local CA into the system trust store on first run. See README for setup.
+const DEV_HOST = 'dev.tidal.com';
+const DEV_PORT = 5173;
 
 export default defineConfig(({ mode }) => {
   // Load env file based on `mode` in the current working directory.
@@ -27,9 +34,12 @@ export default defineConfig(({ mode }) => {
     plugins: [
       version(),
       dts({ rollupTypes: false, tsconfigPath: 'tsconfig.build.json' }),
+      mkcert({ hosts: [DEV_HOST] }),
     ],
     server: {
-      open: '/demo/index.html',
+      host: DEV_HOST,
+      open: `https://${DEV_HOST}:${DEV_PORT}/demo/index.html`,
+      port: DEV_PORT,
     },
     test: {
       coverage: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,6 +295,9 @@ importers:
       vite-plugin-dts:
         specifier: 4.5.4
         version: 4.5.4(@types/node@24.12.2)(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(terser@5.31.0)(yaml@2.8.3))
+      vite-plugin-mkcert:
+        specifier: 2.0.0
+        version: 2.0.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(terser@5.31.0)(yaml@2.8.3))
       vite-plugin-package-version:
         specifier: 1.1.0
         version: 1.1.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(terser@5.31.0)(yaml@2.8.3))
@@ -4819,7 +4822,6 @@ packages:
 
   shaka-player@5.1.2:
     resolution: {integrity: sha512-Drkt3Hw1E9lrzMVZr6UEq8Z3tT/S2i8I9btUuS30gRvKN+kjrgvIJYMlNHVEc616SYEpXqdguF+asqfPrn1kDQ==}
-    engines: {node: '>=18'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5269,6 +5271,10 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici@8.1.0:
+    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
+    engines: {node: '>=22.19.0'}
+
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -5341,6 +5347,12 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vite-plugin-mkcert@2.0.0:
+    resolution: {integrity: sha512-+5roXeOT91WRO3NKFRcDZKEHhze/1uahSSKOIq3vz2w19mJojBcyOo0JyLRHbME31Ym5qPRNJ8CwKO0mu4RJ2Q==}
+    engines: {node: '>=22.19.0'}
+    peerDependencies:
+      vite: '>=3'
 
   vite-plugin-package-version@1.1.0:
     resolution: {integrity: sha512-TPoFZXNanzcaKCIrC3e2L/TVRkkRLB6l4RPN/S7KbG7rWfyLcCEGsnXvxn6qR7fyZwXalnnSN/I9d6pSFjHpEA==}
@@ -7348,7 +7360,7 @@ snapshots:
       '@types/node': 24.12.2
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.1)(typescript@5.9.3))(eslint@10.0.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.0.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       '@typescript-eslint/parser': 8.56.0(eslint@10.0.1)(typescript@5.9.3)
@@ -8811,7 +8823,7 @@ snapshots:
       '@eslint/eslintrc': 3.3.3
       '@eslint/js': 10.0.1(eslint@10.0.1)
       '@jambit/eslint-plugin-typed-redux-saga': 0.4.0
-      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.1)(typescript@5.9.3))(eslint@10.0.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.2.1)(typescript@6.0.3))(eslint@10.0.1)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.56.0(eslint@10.0.1)(typescript@5.9.3)
       '@vitest/eslint-plugin': 1.6.9(eslint@10.0.1)(typescript@5.9.3)(vitest@4.0.18(@types/node@24.12.2)(happy-dom@20.9.0)(lightningcss@1.32.0)(terser@5.31.0)(yaml@2.8.3))
       confusing-browser-globals: 1.0.11
@@ -8823,7 +8835,7 @@ snapshots:
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.0.1)
       eslint-plugin-no-only-tests: 3.3.0
       eslint-plugin-perfectionist: 5.6.0(eslint@10.0.1)(typescript@5.9.3)
-      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.1))(eslint@10.0.1)(prettier@3.8.1)
+      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.2.1))(eslint@10.0.1)(prettier@3.8.1)
       eslint-plugin-react: 7.37.5(eslint@10.0.1)
       eslint-plugin-react-hooks: 7.0.1(eslint@10.0.1)
       eslint-plugin-storybook: 10.2.10(eslint@10.0.1)(storybook@10.2.10(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
@@ -8989,7 +9001,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.1))(eslint@10.0.1)(prettier@3.8.1):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.2.1))(eslint@10.0.1)(prettier@3.8.1):
     dependencies:
       eslint: 10.0.1
       prettier: 3.8.1
@@ -11161,6 +11173,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici@8.1.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -11252,6 +11266,13 @@ snapshots:
       - '@types/node'
       - rollup
       - supports-color
+
+  vite-plugin-mkcert@2.0.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(terser@5.31.0)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      supports-color: 10.2.2
+      undici: 8.1.0
+      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(terser@5.31.0)(yaml@2.8.3)
 
   vite-plugin-package-version@1.1.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(terser@5.31.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
## Summary

- Switch `pnpm dev` and Cypress E2E in `packages/player` to HTTPS at `https://dev.tidal.com:5173`. Cert generation and trust are handled by [`vite-plugin-mkcert`](https://www.npmjs.com/package/vite-plugin-mkcert); nothing cert-related is checked in.
- Make demo `tlConsumer*Uri` host-agnostic via `window.location.origin`, and switch the Cypress intercept to a path-only glob.
- Update Cypress `baseUrl` and replace absolute `cy.visit(...)` URLs with paths relative to it.
- Add a `/etc/hosts` step to the Cypress GitHub Actions workflow and switch `wait-on` to `tcp:` so strict-SSL is bypassed; Chromium ignores cert errors via `cypress.config.js`.
- Extend the dev-only logging gates in `basePlayer.ts` and `load.ts` to also fire on `dev.tidal.com` (previously `localhost`-only).

See the updated `packages/player/README.md` for one-time per-machine setup.

## Test plan

Local:
- [ ] Add `127.0.0.1 dev.tidal.com` to `/etc/hosts`.
- [ ] `pnpm --dir packages/player dev` opens `https://dev.tidal.com:5173/demo/index.html` (first run prompts once for sudo so mkcert can install its local CA).
- [ ] Demo test cases load and play.
- [ ] `pnpm --dir packages/player cypress:open` runs the play-log specs against the secure URL.

CI:
- [ ] Existing `Cypress Tests` workflow passes on this branch.
- [ ] `pnpm --dir packages/player typecheck`, `lint`, and `build` remain clean (verified locally; build is unaffected since mkcert is a serve-only plugin).


Made with [Cursor](https://cursor.com)