### PR TITLE
fix: Vitest extension config resolution for vite-plugin-mkcert

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typedoc": "0.28.19",
     "vite": "8.0.10",
     "vite-plugin-dts": "5.0.0",
+    "vite-plugin-mkcert": "2.0.0",
     "vite-plugin-package-version": "1.1.0",
     "vitest": "4.1.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       vite-plugin-dts:
         specifier: 5.0.0
         version: 5.0.0(@microsoft/api-extractor@7.51.1(@types/node@24.12.2))(esbuild@0.28.0)(rollup@4.60.3)(typescript@6.0.3)(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(terser@5.31.0)(yaml@2.8.3))
+      vite-plugin-mkcert:
+        specifier: 2.0.0
+        version: 2.0.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(terser@5.31.0)(yaml@2.8.3))
       vite-plugin-package-version:
         specifier: 1.1.0
         version: 1.1.0(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.0)(terser@5.31.0)(yaml@2.8.3))
@@ -4797,7 +4800,6 @@ packages:
 
   shaka-player@5.1.3:
     resolution: {integrity: sha512-oOmOn8tG7n2rgur1BYbfx2MoYvkUMRKKLjfXOR4C5PgWLQuMVhXaD54TTJ8ze/pXncAQbw5ZXiUdX0z3qiZZtQ==}
-    engines: {node: '>=18'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -7400,7 +7402,7 @@ snapshots:
       '@types/node': 24.12.2
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.1)(typescript@5.9.3))(eslint@10.0.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.3.0)(typescript@6.0.3))(eslint@10.0.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       '@typescript-eslint/parser': 8.56.0(eslint@10.0.1)(typescript@5.9.3)
@@ -8829,7 +8831,7 @@ snapshots:
       '@eslint/eslintrc': 3.3.3
       '@eslint/js': 10.0.1(eslint@10.0.1)
       '@jambit/eslint-plugin-typed-redux-saga': 0.4.0
-      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.0.1)(typescript@5.9.3))(eslint@10.0.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.0(@typescript-eslint/parser@8.56.0(eslint@10.3.0)(typescript@6.0.3))(eslint@10.0.1)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.56.0(eslint@10.0.1)(typescript@5.9.3)
       '@vitest/eslint-plugin': 1.6.9(eslint@10.0.1)(typescript@5.9.3)(vitest@4.0.18(@types/node@24.12.2)(happy-dom@20.9.0)(lightningcss@1.32.0)(terser@5.31.0)(yaml@2.8.3))
       confusing-browser-globals: 1.0.11
@@ -8841,7 +8843,7 @@ snapshots:
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.0.1)
       eslint-plugin-no-only-tests: 3.3.0
       eslint-plugin-perfectionist: 5.6.0(eslint@10.0.1)(typescript@5.9.3)
-      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.1))(eslint@10.0.1)(prettier@3.8.1)
+      eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.3.0))(eslint@10.0.1)(prettier@3.8.1)
       eslint-plugin-react: 7.37.5(eslint@10.0.1)
       eslint-plugin-react-hooks: 7.0.1(eslint@10.0.1)
       eslint-plugin-storybook: 10.2.10(eslint@10.0.1)(storybook@10.2.10(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
@@ -9007,7 +9009,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.0.1))(eslint@10.0.1)(prettier@3.8.1):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@10.3.0))(eslint@10.0.1)(prettier@3.8.1):
     dependencies:
       eslint: 10.0.1
       prettier: 3.8.1


### PR DESCRIPTION
## Summary

The Vitest VS Code extension fails to start with:

```
Vitest failed to start:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vite-plugin-mkcert'
imported from /…/node_modules/.vite-temp/vite.config.js.timestamp-….mjs
```

The extension materialises each package's `vite.config.ts` into `<workspace>/node_modules/.vite-temp/`. Under pnpm strict resolution, that temp file can only see packages declared in the **root** `node_modules`, not the per‑package ones.

#558 already hoisted `vite`, `vite-plugin-dts`, and `vite-plugin-package-version` for exactly this reason. #614 then added `vite-plugin-mkcert` to `packages/player` only, reintroducing the same failure mode for that plugin.

This PR hoists `vite-plugin-mkcert@2.0.0` (matching the player's version) into the root `devDependencies`. The existing `vitest.exclude` entry for `packages/player/**` only stops test discovery; it does not stop config loading, so it doesn't address this on its own.

## Notes

- The lockfile diff also contains a few entries unrelated to this change (a `shaka-player` engines field removal and some `@typescript-eslint/eslint-plugin` / `eslint-plugin-prettier` peer-dep snapshot key re-keys). Those are produced by pnpm regenerating against the current `main` lockfile on **any** `pnpm install` and are not caused by adding `vite-plugin-mkcert`.

## Test plan

- [ ] `pnpm install` succeeds.
- [ ] In Cursor/VS Code with the Vitest extension enabled, the extension starts without the `vite-plugin-mkcert` resolution error.
- [ ] Vitest still discovers and runs tests in non-player packages.
- [ ] `packages/player` workflows (Web Test Runner, `pnpm dev`, `vite build`) are unaffected.


Made with [Cursor](https://cursor.com)