### PR TITLE
fix(ci): release-trigger drops all but last package on multi-bump PRs

### DIFF
--- a/.github/workflows/check-changelog-files.yml
+++ b/.github/workflows/check-changelog-files.yml
@@ -25,6 +25,15 @@ jobs:
           modules_list=()
           while IFS= read -r file; do
             [ -z "$file" ] && continue
+            # tj-actions/changed-files@v47 with `separator: "\n"` writes the
+            # paths to $GITHUB_OUTPUT as `path1\<NL>path2\<NL>...pathN`, i.e. a
+            # literal backslash before each newline. Without this strip the
+            # check below sees `packages/foo/package.json\` (with trailing
+            # backslash), the file doesn't exist, and the package is dropped
+            # from the changelog check matrix. Only the last entry has no
+            # trailing backslash, so previously only the last bumped package
+            # was checked when a PR bumped multiple packages.
+            file="${file%\\}"
             ./bin/check-version-bump.sh ./"$file"
 
             # check-version-bump exits with 0 if it detects a bump, otherwise with 1

--- a/.github/workflows/trigger-releases.yml
+++ b/.github/workflows/trigger-releases.yml
@@ -27,6 +27,15 @@ jobs:
           modules_list=()
           while IFS= read -r file; do
             [ -z "$file" ] && continue
+            # tj-actions/changed-files@v47 with `separator: "\n"` writes the
+            # paths to $GITHUB_OUTPUT as `path1\<NL>path2\<NL>...pathN`, i.e. a
+            # literal backslash before each newline. Without this strip the
+            # check below sees `packages/foo/package.json\` (with trailing
+            # backslash), the file doesn't exist, and the package is dropped
+            # from the release matrix. Only the last entry has no trailing
+            # backslash, so previously only the last bumped package was
+            # released when a PR bumped multiple packages.
+            file="${file%\\}"
             ./bin/check-version-bump.sh ./"$file"
 
             # check-version-bump exits with 0 if it detects a bump, otherwise with 1


### PR DESCRIPTION
## Summary

When a PR bumps multiple packages' `version` in a single commit, only the
**last** one (alphabetically) was getting a GitHub release and CHANGELOG
check. This bit #634, which bumped 7 packages but produced only a single
GH release for `true-time`. npm publish was unaffected because the
`release-to-npm.yml` step uses `pnpm publish -r`, which walks the whole
workspace independently of the release matrix — so the 6 missed
packages did still get published to npm, just without GH releases (those
have since been backfilled manually).

## Root cause

`tj-actions/changed-files@v47` with `separator: "\n"` writes the
changed-file list to `$GITHUB_OUTPUT` with a **literal backslash** in
front of each newline:

```
ALL_CHANGED_FILES: packages/api/package.json\
packages/auth/package.json\
packages/common/package.json\
...
packages/true-time/package.json
```

Both `trigger-releases.yml` and `check-changelog-files.yml` then iterate
with `while IFS= read -r file`. The first N-1 lines come out as
`packages/<pkg>/package.json\` — the literal backslash is part of the
string. `check-version-bump.sh ./"$file"` therefore tests
`[ -f "./packages/<pkg>/package.json\\" ]`, which doesn't exist, the
script aborts with `File not found`, and the package is silently dropped
from the matrix. Only the last entry (`true-time` here) is unescaped and
makes it through.

Evidence from the failing
[release run](https://github.com/tidal-music/tidal-sdk-web/actions/runs/25794467388):

```
File './packages/api/package.json\' not found. Cannot check for version bump in ''
File './packages/auth/package.json\' not found. Cannot check for version bump in ''
File './packages/common/package.json\' not found. Cannot check for version bump in ''
File './packages/event-producer/package.json\' not found. Cannot check for version bump in ''
File './packages/player-web-components/package.json\' not found. Cannot check for version bump in ''
File './packages/player/package.json\' not found. Cannot check for version bump in ''
File './packages/template/package.json\' not found. Cannot check for version bump in ''
Checking version entry in '.../packages/true-time/package.json'   # <-- the only survivor
Version bump detected
```

This bug has been latent because almost every prior PR bumps exactly one
package's `package.json`, and that one always happens to be the last
loop iteration (no trailing backslash). #634 is the first multi-bump PR
and tripped it.

## Fix

Strip the trailing `\` from each `file` line before using it, in both
workflows. Reproduction + verification of the fix:

```
BEFORE:
  file=[packages/api/package.json\]  exists=NO
  file=[packages/auth/package.json\]  exists=NO
  file=[packages/common/package.json\]  exists=NO
  file=[packages/true-time/package.json]  exists=yes

AFTER:
  file=[packages/api/package.json]  exists=yes
  file=[packages/auth/package.json]  exists=yes
  file=[packages/common/package.json]  exists=yes
  file=[packages/true-time/package.json]  exists=yes
```

## Test plan

- [x] Reproduced the failing env-var content from the run log locally
      and confirmed the bash loop skips the first N-1 entries without
      the fix, and processes all entries with the fix.
- [ ] After merge: next multi-package release PR should trigger
      releases / changelog checks for every bumped package, not just
      the last one. (The lint, type-check, unit-test, and types-resolution
      jobs from this PR will run on this PR even though the workflows
      it edits only fire on `push: main`.)

## Notes

- I'm intentionally not changing the `tj-actions/changed-files`
  separator config — the strip is a minimal defensive fix that also
  protects against any future re-introduction of the same escape
  behaviour.
- An alternative would be to drop `separator: "\n"` entirely and use
  the default space separator. None of our file paths contain spaces,
  so that would work too, but it's a bigger conceptual change and
  doesn't add safety beyond the strip.


Made with [Cursor](https://cursor.com)