### PR TITLE
chore(common,true-time): enable isolatedDeclarations for build emit

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -30,7 +30,7 @@
     "test": "vitest",
     "test:coverage": "pnpm run test --coverage",
     "test:ui": "pnpm run test:coverage --ui",
-    "typecheck": "tsc",
+    "typecheck": "tsc && tsc -p tsconfig.build.json",
     "check:types-resolution": "attw --pack . --ignore-rules=cjs-resolves-to-esm"
   },
   "devDependencies": {

--- a/packages/common/tsconfig.build.json
+++ b/packages/common/tsconfig.build.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "isolatedDeclarations": true
+  },
   "include": ["src"],
   "exclude": ["node_modules", "test", "src/**/*.test.ts"]
 }

--- a/packages/true-time/package.json
+++ b/packages/true-time/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build -m development",
     "clean": "rm -rf coverage dist .eslintcache",
-    "typecheck": "tsc",
+    "typecheck": "tsc && tsc -p tsconfig.build.json",
     "check:types-resolution": "attw --pack . --ignore-rules=cjs-resolves-to-esm",
     "lint": "eslint . --cache --cache-strategy content",
     "lint:ci": "eslint . --quiet",

--- a/packages/true-time/src/index.ts
+++ b/packages/true-time/src/index.ts
@@ -19,7 +19,7 @@ export class TrueTime {
    * @returns The current adjusted time (or the client time if not synced yet).
    */
   // eslint-disable-next-line no-restricted-syntax
-  now(clientCurrentTime = Date.now()): number {
+  now(clientCurrentTime: number = Date.now()): number {
     if (!this.#serverTime || !this.#clientStartTime) {
       console.warn('TrueTime is not yet synchronized');
       return clientCurrentTime;
@@ -91,4 +91,4 @@ export class TrueTime {
   }
 }
 
-export const trueTime = new TrueTime('https://api.tidal.com/v1/ping');
+export const trueTime: TrueTime = new TrueTime('https://api.tidal.com/v1/ping');

--- a/packages/true-time/tsconfig.build.json
+++ b/packages/true-time/tsconfig.build.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "isolatedDeclarations": true
+  },
   "include": ["src"],
   "exclude": ["node_modules", "test", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Turns on `--isolatedDeclarations` in `tsconfig.build.json` for `@tidal-music/common` and `@tidal-music/true-time`, so `.d.ts` emit can be done file-at-a-time without a whole-program type-check. This is the foundation for future JSR/Deno publishing and also catches accidentally-inferred public types creeping into the API surface.
- `common` already passed the flag cleanly. `true-time` needed two trivial annotations (`now(clientCurrentTime: number = Date.now())` and `export const trueTime: TrueTime = …`); neither changes the emitted `.d.ts`.
- Wires `tsc -p tsconfig.build.json` into each package's `typecheck` script for real CI enforcement — `vite-plugin-dts` prints isolated-declaration errors but exits 0, so it can't be relied on as a gate.

Closes #151, which attempted the same flip for `common`, `true-time` and `player`. The player portion has drifted heavily (200+ lines of new errors against today's tree) and is best done as a separate, tool-driven pass (lint rule + mechanical sweep) rather than rebased.

## Test plan

- [x] `pnpm --filter @tidal-music/common --filter @tidal-music/true-time typecheck`
- [x] `pnpm --filter @tidal-music/common --filter @tidal-music/true-time build` — `vite-plugin-dts` emits `.d.ts` shapes byte-identical to before
- [x] `pnpm --filter @tidal-music/common --filter @tidal-music/true-time test --run`
- [x] `pnpm --filter @tidal-music/common --filter @tidal-music/true-time lint:ci`
- [x] `pnpm check:types-resolution` (attw, both packages clean)
- [x] Verified regression detection by temporarily reverting the `trueTime` annotation — `typecheck` exits non-zero with `TS9010`.

Made with [Cursor](https://cursor.com)