### PR TITLE
fix(player): use v2 trackManifests API for all authenticated track requests

### DIFF
--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -7,11 +7,9 @@ import { fetchPlaybackInfo } from './playback-info-resolver.js';
 describe('playbackInfoResolver', () => {
   authAndEvents(before, after);
 
-  it('fetches playback info via legacy API if there is only clientId defined, gets preview', async () => {
+  it('fetches playback info via legacy API when no accessToken is provided, gets preview', async () => {
     const { clientId } = await credentialsProvider.getCredentials();
 
-    // Use playerType: 'native' to test the legacy v1 playbackinfo endpoint
-    // which supports preview access without a full access token
     const result = await fetchPlaybackInfo({
       accessToken: undefined,
       audioAdaptiveBitrateStreaming: true,
@@ -23,7 +21,6 @@ describe('playbackInfoResolver', () => {
         sourceId: '',
         sourceType: '',
       },
-      playerType: 'native',
       prefetch: false,
       // eslint-disable-next-line no-restricted-syntax
       streamingSessionId: `tidal-player-js-test-${Date.now()}`,
@@ -34,14 +31,13 @@ describe('playbackInfoResolver', () => {
     expect(result.manifest).to.not.equal(undefined);
   });
 
-  it('fetches playback info via legacy API if there is an accessToken defined, gets full', async () => {
+  it('fetches playback info via trackManifests API when accessToken is provided, even for native player type', async () => {
     const { clientId, token } = await credentialsProvider.getCredentials();
 
     if (!token) {
       throw new Error('No access token, cannot fulfill test.');
     }
 
-    // Use playerType: 'native' to test the legacy v1 playbackinfo endpoint
     const result = await fetchPlaybackInfo({
       accessToken: token,
       audioAdaptiveBitrateStreaming: true,

--- a/packages/player/src/internal/helpers/playback-info-resolver.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.ts
@@ -533,10 +533,12 @@ export async function fetchPlaybackInfo(options: Options) {
   try {
     let playbackInfo: PlaybackInfo;
 
-    if (options.playerType === 'native') {
-      playbackInfo = await _fetchLegacyPlaybackInfo(options);
-    } else if (options.mediaProduct.productType === 'video') {
+    if (options.mediaProduct.productType === 'video') {
       playbackInfo = await _fetchVideoManifest(options);
+    } else if (!options.accessToken) {
+      // Legacy v1 API is needed for preview access without a full access token,
+      // since the v2 trackManifests endpoint requires authentication.
+      playbackInfo = await _fetchLegacyPlaybackInfo(options);
     } else {
       playbackInfo = await _fetchTrackManifest(options);
     }


### PR DESCRIPTION
## Summary

- Desktop apps that bootstrap with `player: 'native'` were being routed to the legacy v1 `api.tidal.com/v1/tracks/{id}/playbackinfo` endpoint instead of the v2 `openapi.tidal.com/v2/trackManifests/{id}` endpoint, because `fetchPlaybackInfo` used `playerType` to decide which API to call
- This meant desktop never received paywall-related fields like `previewReason` from the API response
- Decouples the API endpoint choice from the player type: all authenticated track requests now use the v2 `trackManifests` API regardless of player type; the legacy v1 endpoint is only used for unauthenticated preview access (no access token)

## Test plan

- [x] Verify desktop player now calls `openapi.tidal.com/v2/trackManifests/{id}` instead of `api.tidal.com/v1/tracks/{id}/playbackinfo`
- [x] Verify `previewReason` is present in playback info for paywalled content on desktop
- [x] Verify web player behavior is unchanged (was already using v2)
- [x] Run existing integration tests for playback-info-resolver

[logged in with subscription]
Demo showing this sdk branch on desktop playing requires subscription tracks and requires purchase album and tracks. 
https://github.com/user-attachments/assets/7b8b06ea-7a33-48ac-b4b5-f47f5a1cf30a


[logged in with no subscription]
Demo showing this sdk branch playing requires subscription tracks and requires purchase album and tracks. 
https://github.com/user-attachments/assets/f5060671-5f18-455d-85cf-55840361f044
