### PR TITLE
fix(event-producer): abort batch POST after 10s so blocked telemetry can't stall the host app

### DIFF
--- a/packages/event-producer/CHANGELOG.md
+++ b/packages/event-producer/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `submitEvents` now aborts the batch `POST` after a 5 s timeout and treats fetch errors as an outage (events stay queued for retry) so a network/SSL-inspection device that silently drops the telemetry request can no longer block the event loop and stall playback in the consuming app.
+- `submitEvents` now aborts the batch `POST` after a 10 s timeout and treats fetch errors as an outage (events stay queued for retry) so a network/SSL-inspection device that silently drops the telemetry request can no longer block the event loop and stall playback in the consuming app.
 
 ## [2.4.1] - 2026-05-13
 

--- a/packages/event-producer/CHANGELOG.md
+++ b/packages/event-producer/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2026-05-22
+
+### Fixed
+
+- `submitEvents` now aborts the batch `POST` after a 5 s timeout and treats fetch errors as an outage (events stay queued for retry) so a network/SSL-inspection device that silently drops the telemetry request can no longer block the event loop and stall playback in the consuming app.
+
 ## [2.4.1] - 2026-05-13
 
 ### Fixed

--- a/packages/event-producer/package.json
+++ b/packages/event-producer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/event-producer",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/event-producer/src/submit/submit.test.ts
+++ b/packages/event-producer/src/submit/submit.test.ts
@@ -304,4 +304,34 @@ describe.sequential('submit', () => {
 
     expect(queue.setEvents).toHaveBeenCalledWith([epEvent1]);
   });
+
+  it('triggers outage on fetch timeout (AbortError) and does not remove events', async () => {
+    vi.spyOn(outage, 'setOutage');
+    vi.mocked(queue).getEventBatch.mockReturnValue([epEvent1]);
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockRejectedValue(
+          new DOMException('The operation was aborted.', 'AbortError'),
+        ),
+    );
+    await submitEvents({ config });
+
+    expect(outage.setOutage).toHaveBeenCalledWith(true);
+    expect(queue.removeEvents).not.toHaveBeenCalled();
+  });
+
+  it('triggers outage on network error and does not remove events', async () => {
+    vi.spyOn(outage, 'setOutage');
+    vi.mocked(queue).getEventBatch.mockReturnValue([epEvent1]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+    );
+    await submitEvents({ config });
+
+    expect(outage.setOutage).toHaveBeenCalledWith(true);
+    expect(queue.removeEvents).not.toHaveBeenCalled();
+  });
 });

--- a/packages/event-producer/src/submit/submit.ts
+++ b/packages/event-producer/src/submit/submit.ts
@@ -39,11 +39,25 @@ export const submitEvents = async ({
   }
   const uri = accessToken ? config.tlConsumerUri : config.tlPublicConsumerUri;
   const body = eventsToSqsRequestParameters(eventsBatch);
-  const res = await fetch(uri, {
-    body,
-    headers,
-    method: 'post',
-  });
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+  let res: Response;
+  try {
+    res = await fetch(uri, {
+      body,
+      headers,
+      method: 'post',
+      signal: controller.signal,
+    });
+  } catch {
+    clearTimeout(timeoutId);
+    setOutage(true);
+    return;
+  }
+  clearTimeout(timeoutId);
+
   if (res.ok) {
     if (isOutage()) {
       setOutage(false);

--- a/packages/event-producer/src/submit/submit.ts
+++ b/packages/event-producer/src/submit/submit.ts
@@ -41,7 +41,7 @@ export const submitEvents = async ({
   const body = eventsToSqsRequestParameters(eventsBatch);
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
 
   let res: Response;
   try {


### PR DESCRIPTION
## Summary

A TIDAL desktop user reported reproducible playback freezes every 2–3 tracks. The freeze was correlated exactly with their home network's SSL-inspection device silently dropping the outbound EventProducer batch `POST`.

The desktop client routes `/api/event-batch` and the playback-control APIs (`/v2/*`) through the same origin. When the telemetry `fetch` in `submitEvents` hangs indefinitely waiting for a response that will never come, it can starve the shared HTTP connection pool used by the renderer for the next-track / streaming-info calls, causing the UI to keep showing "playing" while audio is stuck.

This change wraps the batch `fetch` in an `AbortController` with a 10 s timeout and treats abort / network errors the same as a backend outage: `setOutage(true)` and return early without dequeueing. Events stay in the queue and are retried on the next scheduler tick — no data loss, just graceful degradation when the network is hostile.

### What changed

- `packages/event-producer/src/submit/submit.ts`: add `AbortController` + 10 s timeout around the batch `POST`; on abort / fetch error, call `setOutage(true)` and return early (events stay queued).
- `packages/event-producer/src/submit/submit.test.ts`: two new tests covering the `AbortError` (timeout) and the generic `TypeError` (network error) paths, both asserting `setOutage(true)` is called and `removeEvents` is **not** called.
- `packages/event-producer/package.json`: bump to `2.4.2`.
- `packages/event-producer/CHANGELOG.md`: matching `Fixed` entry.

## Test plan

- [x] `pnpm test` in `packages/event-producer` — `34 passed (34)` across 11 files
- [x] `pnpm lint` — `0 errors` (pre-existing warnings only, none in changed files)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean (run as part of typecheck dependencies)