### PR TITLE
Add share-code attribute to tidal-play-trigger (0.3.0)

### DIFF
--- a/packages/player-web-components/CHANGELOG.md
+++ b/packages/player-web-components/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-06-16
+
+### Added
+
+- `share-code` attribute on `<tidal-play-trigger>` for playback of unlisted upload shares via the Player SDK `MediaProduct.shareCode` field.
+
 ## [0.2.2] - 2026-05-13
 
 ### Fixed

--- a/packages/player-web-components/demo/index.html
+++ b/packages/player-web-components/demo/index.html
@@ -194,6 +194,11 @@
           <td>'track' | 'video'</td>
           <td>Product type to be played</td>
         </tr>
+        <tr>
+          <td>share-code</td>
+          <td>shareCode</td>
+          <td>Optional share code for unlisted upload tracks (requires <code>product-type="track"</code>)</td>
+        </tr>
       </tbody>
     </table>
     <h3>Example</h3>

--- a/packages/player-web-components/package.json
+++ b/packages/player-web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/player-web-components",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "type": "module",
   "module": "dist/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/player-web-components/src/tidal-play-trigger.ts
+++ b/packages/player-web-components/src/tidal-play-trigger.ts
@@ -19,7 +19,7 @@ class TidalPlayTrigger extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ['product-id', 'product-type'];
+    return ['product-id', 'product-type', 'share-code'];
   }
 
   async #loadAndPlay() {
@@ -33,14 +33,15 @@ class TidalPlayTrigger extends HTMLElement {
   }
 
   #loadIfNotLoaded() {
-    const currentProductIdInPlayer =
-      Player.getMediaProduct()?.productId ?? undefined;
+    const currentMediaProduct = Player.getMediaProduct();
+    const nextMediaProduct = this.mediaProduct;
 
     if (
-      this.mediaProduct &&
-      this.mediaProduct.productId !== currentProductIdInPlayer
+      nextMediaProduct &&
+      (currentMediaProduct?.productId !== nextMediaProduct.productId ||
+        currentMediaProduct?.shareCode !== nextMediaProduct.shareCode)
     ) {
-      return Player.load(this.mediaProduct, 0);
+      return Player.load(nextMediaProduct, 0);
     }
 
     return undefined;
@@ -89,10 +90,12 @@ class TidalPlayTrigger extends HTMLElement {
 
     const productType =
       this.getAttribute('product-type') === 'video' ? 'video' : 'track';
+    const shareCode = this.getAttribute('share-code') ?? undefined;
 
     return {
       productId,
       productType,
+      shareCode,
       sourceId: '',
       sourceType: '',
     };

--- a/packages/player-web-components/src/tidal-play-trigger.ts
+++ b/packages/player-web-components/src/tidal-play-trigger.ts
@@ -39,6 +39,7 @@ class TidalPlayTrigger extends HTMLElement {
     if (
       nextMediaProduct &&
       (currentMediaProduct?.productId !== nextMediaProduct.productId ||
+        currentMediaProduct?.productType !== nextMediaProduct.productType ||
         currentMediaProduct?.shareCode !== nextMediaProduct.shareCode)
     ) {
       return Player.load(nextMediaProduct, 0);
@@ -90,7 +91,8 @@ class TidalPlayTrigger extends HTMLElement {
 
     const productType =
       this.getAttribute('product-type') === 'video' ? 'video' : 'track';
-    const shareCode = this.getAttribute('share-code') ?? undefined;
+    const rawShareCode = this.getAttribute('share-code');
+    const shareCode = rawShareCode?.trim() || undefined;
 
     return {
       productId,


### PR DESCRIPTION
## Summary
- Add optional `share-code` attribute to `<tidal-play-trigger>` and pass it through as `MediaProduct.shareCode`
- Reload when either `productId` or `shareCode` changes (needed for unlisted upload shares)
- Bump `@tidal-music/player-web-components` to **0.3.0**

## Context
Player SDK 0.18.x fetches unlisted upload manifests via `/trackManifests/{id}?shareCode=…`, but the web component only exposed `product-id` and `product-type`. Embed player upload playback was broken because it could not pass the share code.

Consumers should set:
- `product-id` — track id
- `product-type="track"`
- `share-code` — upload share UUID

## Test plan
- [x] `pnpm run typecheck` in `packages/player-web-components`
- [x] `pnpm run lint:ci` in `packages/player-web-components`
- [x] `pnpm run test --run` in `packages/player-web-components`
- [ ] After publish: bump embed-player to `@tidal-music/player-web-components@0.3.0` and wire SSR attributes


Made with [Cursor](https://cursor.com)