### PR TITLE
Fix streaming metrics timestamp races

### DIFF
--- a/packages/player/src/internal/handlers/load.ts
+++ b/packages/player/src/internal/handlers/load.ts
@@ -6,6 +6,7 @@ import { generateGUID } from '../../internal/helpers/generate-guid.js';
 import { parseManifest } from '../../internal/helpers/manifest-parser.js';
 import { fetchPlaybackInfo } from '../../internal/helpers/playback-info-resolver.js';
 import type { PlaybackInfo } from '../../internal/helpers/playback-info-resolver.js';
+import { timestamps } from '../../internal/helpers/streaming-metrics-timestamps.js';
 import { streamingSessionStore } from '../../internal/helpers/streaming-session-store.js';
 import {
   PlayerError,
@@ -73,12 +74,9 @@ export async function load(
   ) {
     const player = playerState.activePlayer;
 
-    performance.mark(
+    timestamps.mark(
       'streaming_metrics:playback_statistics:idealStartTimestamp',
-      {
-        detail: playerState.preloadedStreamingSessionId,
-        startTime: trueTime.now(),
-      },
+      playerState.preloadedStreamingSessionId,
     );
 
     await player.reset({ keepPreload: true });
@@ -111,12 +109,9 @@ export async function load(
     }),
   ]).catch(console.error);
 
-  performance.mark(
+  timestamps.mark(
     'streaming_metrics:playback_statistics:idealStartTimestamp',
-    {
-      detail: streamingSessionId,
-      startTime: trueTime.now(),
-    },
+    streamingSessionId,
   );
 
   const { clientId, token } =

--- a/packages/player/src/internal/helpers/playback-info-resolver.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.ts
@@ -14,8 +14,8 @@ import type {
   VideoQuality,
 } from '../../internal/types.js';
 import * as StreamingMetrics from '../event-tracking/streaming-metrics/index.js';
+import { timestamps } from '../helpers/streaming-metrics-timestamps.js';
 import { waitFor } from '../helpers/wait-for.js';
-import { trueTime } from '../true-time.js';
 
 type BasePlaybackInfo = {
   /**
@@ -501,10 +501,10 @@ export async function fetchPlaybackInfo(options: Options) {
   const { streamingSessionId } = options;
   const events = [];
 
-  performance.mark('streaming_metrics:playback_info_fetch:startTimestamp', {
-    detail: streamingSessionId,
-    startTime: trueTime.now(),
-  });
+  timestamps.mark(
+    'streaming_metrics:playback_info_fetch:startTimestamp',
+    streamingSessionId,
+  );
 
   try {
     let playbackInfo: PlaybackInfo;
@@ -553,17 +553,17 @@ export async function fetchPlaybackInfo(options: Options) {
       }).catch(console.error);
     }
 
-    performance.mark('streaming_metrics:playback_info_fetch:endTimestamp', {
-      detail: streamingSessionId,
-      startTime: trueTime.now(),
-    });
+    timestamps.mark(
+      'streaming_metrics:playback_info_fetch:endTimestamp',
+      streamingSessionId,
+    );
 
     return playbackInfo;
   } catch (e) {
-    performance.mark('streaming_metrics:playback_info_fetch:endTimestamp', {
-      detail: streamingSessionId,
-      startTime: trueTime.now(),
-    });
+    timestamps.mark(
+      'streaming_metrics:playback_info_fetch:endTimestamp',
+      streamingSessionId,
+    );
 
     StreamingMetrics.playbackInfoFetch({
       endReason: 'ERROR',
@@ -575,8 +575,9 @@ export async function fetchPlaybackInfo(options: Options) {
     events.push(
       StreamingMetrics.streamingSessionEnd({
         streamingSessionId,
-        timestamp: trueTime.timestamp(
+        timestamp: timestamps.get(
           'streaming_metrics:playback_info_fetch:endTimestamp',
+          streamingSessionId,
         ),
       }),
     );
@@ -586,11 +587,13 @@ export async function fetchPlaybackInfo(options: Options) {
   } finally {
     events.push(
       StreamingMetrics.playbackInfoFetch({
-        endTimestamp: trueTime.timestamp(
+        endTimestamp: timestamps.get(
           'streaming_metrics:playback_info_fetch:endTimestamp',
+          streamingSessionId,
         ),
-        startTimestamp: trueTime.timestamp(
+        startTimestamp: timestamps.get(
           'streaming_metrics:playback_info_fetch:startTimestamp',
+          streamingSessionId,
         ),
         streamingSessionId,
       }),
@@ -598,11 +601,13 @@ export async function fetchPlaybackInfo(options: Options) {
 
     StreamingMetrics.commit(events).catch(console.error);
 
-    performance.clearMarks(
+    timestamps.clear(
       'streaming_metrics:playback_info_fetch:endTimestamp',
+      streamingSessionId,
     );
-    performance.clearMarks(
+    timestamps.clear(
       'streaming_metrics:playback_info_fetch:startTimestamp',
+      streamingSessionId,
     );
   }
 }

--- a/packages/player/src/internal/helpers/streaming-metrics-timestamps.test.ts
+++ b/packages/player/src/internal/helpers/streaming-metrics-timestamps.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+
+import { timestamps } from './streaming-metrics-timestamps.js';
+
+describe('streamingMetricsTimestamps', () => {
+  it('stores and retrieves a timestamp by prefix and streaming session id', () => {
+    const prefix = 'streaming_metrics:test:startTimestamp';
+    const streamingSessionId = 'session-with-timestamp';
+
+    timestamps.mark(prefix, streamingSessionId);
+
+    expect(timestamps.get(prefix, streamingSessionId)).to.be.a('number');
+  });
+
+  it('keeps timestamps isolated by streaming session id', () => {
+    const prefix = 'streaming_metrics:test:startTimestamp';
+    const firstStreamingSessionId = 'first-session';
+    const secondStreamingSessionId = 'second-session';
+
+    timestamps.mark(prefix, firstStreamingSessionId);
+
+    expect(timestamps.get(prefix, firstStreamingSessionId)).to.be.a('number');
+    expect(timestamps.get(prefix, secondStreamingSessionId)).to.equal(
+      undefined,
+    );
+  });
+
+  it('clears only the requested timestamp', () => {
+    const prefix = 'streaming_metrics:test:endTimestamp';
+    const otherPrefix = 'streaming_metrics:test:startTimestamp';
+    const streamingSessionId = 'session-to-clear';
+
+    timestamps.mark(prefix, streamingSessionId);
+    timestamps.mark(otherPrefix, streamingSessionId);
+
+    timestamps.clear(prefix, streamingSessionId);
+
+    expect(timestamps.get(prefix, streamingSessionId)).to.equal(undefined);
+    expect(timestamps.get(otherPrefix, streamingSessionId)).to.be.a('number');
+
+    timestamps.clear(otherPrefix, streamingSessionId);
+  });
+
+  it('does nothing when streaming session id is undefined', () => {
+    const prefix = 'streaming_metrics:test:startTimestamp';
+
+    timestamps.mark(prefix, undefined);
+    timestamps.clear(prefix, undefined);
+
+    expect(timestamps.get(prefix, undefined)).to.equal(undefined);
+  });
+});

--- a/packages/player/src/internal/helpers/streaming-metrics-timestamps.ts
+++ b/packages/player/src/internal/helpers/streaming-metrics-timestamps.ts
@@ -30,7 +30,7 @@ function get(prefix: string, streamingSessionId: string | undefined) {
   );
 }
 
-/** Clears previously collected streaming metrics performance marks. */
+/** Clears a previously collected streaming metrics timestamp. */
 function clear(prefix: string, streamingSessionId: string | undefined) {
   if (!streamingSessionId) {
     return;

--- a/packages/player/src/internal/helpers/streaming-metrics-timestamps.ts
+++ b/packages/player/src/internal/helpers/streaming-metrics-timestamps.ts
@@ -1,0 +1,46 @@
+import { trueTime } from '../true-time.js';
+
+const collectedStreamingMetrics = new Map<string, number>();
+
+/** Builds the in-memory key for one timestamp within one streaming session. */
+function timestampKey(prefix: string, streamingSessionId: string) {
+  return `${prefix}:${streamingSessionId}`;
+}
+
+/** Safely collects a timestamp mark for a streaming metrics event. */
+function mark(prefix: string, streamingSessionId: string | undefined) {
+  if (!streamingSessionId) {
+    return;
+  }
+
+  collectedStreamingMetrics.set(
+    timestampKey(prefix, streamingSessionId),
+    trueTime.now(),
+  );
+}
+
+/** Reads a previously collected streaming metrics timestamp. */
+function get(prefix: string, streamingSessionId: string | undefined) {
+  if (!streamingSessionId) {
+    return undefined;
+  }
+
+  return collectedStreamingMetrics.get(
+    timestampKey(prefix, streamingSessionId),
+  );
+}
+
+/** Clears previously collected streaming metrics performance marks. */
+function clear(prefix: string, streamingSessionId: string | undefined) {
+  if (!streamingSessionId) {
+    return;
+  }
+
+  collectedStreamingMetrics.delete(timestampKey(prefix, streamingSessionId));
+}
+
+export const timestamps = {
+  clear,
+  get,
+  mark,
+};

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -432,35 +432,28 @@ export class BasePlayer {
       streamingSessionId,
     );
 
-    try {
-      // Start filling in playbackStatistics
-      StreamingMetrics.playbackStatistics({
-        actualStartTimestamp: timestamps.get(
-          'streaming_metrics:playback_statistics:actualStartTimestamp',
-          streamingSessionId,
-        ),
-        idealStartTimestamp: timestamps.get(
-          'streaming_metrics:playback_statistics:idealStartTimestamp',
-          streamingSessionId,
-        ),
-        outputDevice: this.#outputDeviceType,
-        streamingSessionId,
-      }).catch(console.error);
-    } catch (e) {
-      console.error(
-        e,
-        'actualStartTimestamp or idealStartTimestamp is missing for this streaming session',
-      );
-    } finally {
-      timestamps.clear(
+    // Start filling in playbackStatistics
+    StreamingMetrics.playbackStatistics({
+      actualStartTimestamp: timestamps.get(
         'streaming_metrics:playback_statistics:actualStartTimestamp',
         streamingSessionId,
-      );
-      timestamps.clear(
+      ),
+      idealStartTimestamp: timestamps.get(
         'streaming_metrics:playback_statistics:idealStartTimestamp',
         streamingSessionId,
-      );
-    }
+      ),
+      outputDevice: this.#outputDeviceType,
+      streamingSessionId,
+    }).catch(console.error);
+
+    timestamps.clear(
+      'streaming_metrics:playback_statistics:actualStartTimestamp',
+      streamingSessionId,
+    );
+    timestamps.clear(
+      'streaming_metrics:playback_statistics:idealStartTimestamp',
+      streamingSessionId,
+    );
 
     const mediaProductTransition =
       streamingSessionStore.getMediaProductTransition(streamingSessionId);

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -17,6 +17,7 @@ import { getIsPostPaywall } from '../internal/helpers/get-is-post-paywall.js';
 import type { StreamInfo } from '../internal/helpers/manifest-parser.js';
 import { normalizeVolume } from '../internal/helpers/normalize-volume.js';
 import type { PlaybackInfo } from '../internal/helpers/playback-info-resolver.js';
+import { timestamps } from '../internal/helpers/streaming-metrics-timestamps.js';
 import { streamingSessionStore } from '../internal/helpers/streaming-session-store.js';
 import { waitFor } from '../internal/helpers/wait-for.js';
 import type { OutputType } from '../internal/output-devices.js';
@@ -208,12 +209,9 @@ export class BasePlayer {
     // seamless transition (gapless or crossfade) the next track already
     // started and the correct timestamp was already set at that time.
     if (!isSeamlessTransition && playerState.preloadedStreamingSessionId) {
-      performance.mark(
+      timestamps.mark(
         'streaming_metrics:playback_statistics:idealStartTimestamp',
-        {
-          detail: playerState.preloadedStreamingSessionId,
-          startTime: trueTime.now(),
-        },
+        playerState.preloadedStreamingSessionId,
       );
     }
 
@@ -429,46 +427,38 @@ export class BasePlayer {
       return;
     }
 
-    performance.mark(
+    timestamps.mark(
       'streaming_metrics:playback_statistics:actualStartTimestamp',
-      {
-        detail: streamingSessionId,
-        startTime: trueTime.now(),
-      },
+      streamingSessionId,
     );
-
-    performance.measure('idealStartTimestamp -> actualStartTimestamp', {
-      detail: streamingSessionId,
-      end: 'streaming_metrics:playback_statistics:actualStartTimestamp',
-      start: 'streaming_metrics:playback_statistics:idealStartTimestamp',
-    });
 
     try {
       // Start filling in playbackStatistics
       StreamingMetrics.playbackStatistics({
-        actualStartTimestamp: trueTime.timestamp(
+        actualStartTimestamp: timestamps.get(
           'streaming_metrics:playback_statistics:actualStartTimestamp',
           streamingSessionId,
         ),
-        idealStartTimestamp: trueTime.timestamp(
+        idealStartTimestamp: timestamps.get(
           'streaming_metrics:playback_statistics:idealStartTimestamp',
           streamingSessionId,
         ),
         outputDevice: this.#outputDeviceType,
         streamingSessionId,
-      });
+      }).catch(console.error);
     } catch (e) {
       console.error(
         e,
         'actualStartTimestamp or idealStartTimestamp is missing for this streaming session',
       );
     } finally {
-      performance.clearMarks(
+      timestamps.clear(
         'streaming_metrics:playback_statistics:actualStartTimestamp',
+        streamingSessionId,
       );
-
-      performance.clearMarks(
+      timestamps.clear(
         'streaming_metrics:playback_statistics:idealStartTimestamp',
+        streamingSessionId,
       );
     }
 

--- a/packages/player/src/player/nativePlayer.ts
+++ b/packages/player/src/player/nativePlayer.ts
@@ -7,6 +7,7 @@ import * as Config from '../config.js';
 import { events } from '../event-bus.js';
 import * as StreamingMetrics from '../internal/event-tracking/streaming-metrics/index.js';
 import { composePlaybackContext } from '../internal/helpers/compose-playback-context.js';
+import { timestamps } from '../internal/helpers/streaming-metrics-timestamps.js';
 import { streamingSessionStore } from '../internal/helpers/streaming-session-store.js';
 import { PlayerError } from '../internal/index.js';
 import type { ErrorCodes } from '../internal/index.js';
@@ -161,8 +162,9 @@ export default class NativePlayer extends BasePlayer {
   async #handleNetworkError() {
     this.debugLog('handleNetworkError');
 
-    const actualStartTimestamp = trueTime.timestamp(
+    const actualStartTimestamp = timestamps.get(
       'streaming_metrics:playback_statistics:actualStartTimestamp',
+      this.currentStreamingSessionId,
     );
     const timeSinceStart =
       actualStartTimestamp !== undefined

--- a/packages/player/src/player/shakaPlayer.ts
+++ b/packages/player/src/player/shakaPlayer.ts
@@ -13,6 +13,7 @@ import { composePlaybackContext } from '../internal/helpers/compose-playback-con
 import type { StreamInfo } from '../internal/helpers/manifest-parser.js';
 import { createMediaElementErrorCircuitBreaker } from '../internal/helpers/media-element-error-circuit-breaker.js';
 import type { PlaybackInfo } from '../internal/helpers/playback-info-resolver.js';
+import { timestamps } from '../internal/helpers/streaming-metrics-timestamps.js';
 import { streamingSessionStore } from '../internal/helpers/streaming-session-store.js';
 import { updatePlaybackQuality } from '../internal/helpers/update-playback-quality.js';
 import { waitFor } from '../internal/helpers/wait-for.js';
@@ -22,7 +23,6 @@ import {
   credentialsProviderStore,
 } from '../internal/index.js';
 import type { OutputDevices } from '../internal/output-devices.js';
-import { trueTime } from '../internal/true-time.js';
 
 import { registerAdaptations } from './adaptations.js';
 import {
@@ -554,12 +554,9 @@ export default class ShakaPlayer extends BasePlayer {
       mediaProductTransitionEvent(nextPayload.mediaProduct, playbackContext),
     );
 
-    performance.mark(
+    timestamps.mark(
       'streaming_metrics:playback_statistics:idealStartTimestamp',
-      {
-        detail: nextPayload.streamInfo.streamingSessionId,
-        startTime: trueTime.now(),
-      },
+      nextPayload.streamInfo.streamingSessionId,
     );
 
     this.mediaProductStarted(nextPayload.streamInfo.streamingSessionId);
@@ -739,12 +736,9 @@ export default class ShakaPlayer extends BasePlayer {
               this.currentStreamingSessionId) // If we switch quickly from preload -> current.
             : this.currentStreamingSessionId;
 
-          performance.mark(
+          timestamps.mark(
             'streaming_metrics:drm_license_fetch:startTimestamp',
-            {
-              detail: streamingSessionId,
-              startTime: trueTime.now(),
-            },
+            streamingSessionId,
           );
 
           // Ensure header is octet-stream for license requests
@@ -773,46 +767,41 @@ export default class ShakaPlayer extends BasePlayer {
 
         if (type === shaka.net.NetworkingEngine.RequestType.LICENSE) {
           if (streamingSessionId) {
-            performance.mark(
+            timestamps.mark(
               'streaming_metrics:drm_license_fetch:endTimestamp',
-              {
-                detail: streamingSessionId,
-                startTime: trueTime.now(),
-              },
+              streamingSessionId,
             );
-
-            performance.measure('streaming_metrics:drm_license_fetch', {
-              detail: streamingSessionId,
-              end: 'streaming_metrics:drm_license_fetch:endTimestamp',
-              start: 'streaming_metrics:drm_license_fetch:startTimestamp',
-            });
 
             StreamingMetrics.playbackStatistics({
               cdm: responseURIToCDMType(response.uri),
               cdmVersion: null,
               streamingSessionId,
-            });
+            }).catch(console.error);
 
             StreamingMetrics.commit([
               StreamingMetrics.drmLicenseFetch({
                 endReason: 'COMPLETE',
-                endTimestamp: trueTime.timestamp(
+                endTimestamp: timestamps.get(
                   'streaming_metrics:drm_license_fetch:endTimestamp',
+                  streamingSessionId,
                 ),
                 errorCode: null,
                 errorMessage: null,
-                startTimestamp: trueTime.timestamp(
+                startTimestamp: timestamps.get(
                   'streaming_metrics:drm_license_fetch:startTimestamp',
+                  streamingSessionId,
                 ),
                 streamingSessionId,
               }),
             ]).catch(console.error);
 
-            performance.clearMarks(
+            timestamps.clear(
               'streaming_metrics:drm_license_fetch:endTimestamp',
+              streamingSessionId,
             );
-            performance.clearMarks(
+            timestamps.clear(
               'streaming_metrics:drm_license_fetch:startTimestamp',
+              streamingSessionId,
             );
           }
         }
@@ -889,20 +878,35 @@ export default class ShakaPlayer extends BasePlayer {
           ? (this.preloadedStreamingSessionId ?? this.currentStreamingSessionId)
           : this.currentStreamingSessionId;
         if (failedSessionId) {
+          timestamps.mark(
+            'streaming_metrics:drm_license_fetch:endTimestamp',
+            failedSessionId,
+          );
           StreamingMetrics.commit([
             StreamingMetrics.drmLicenseFetch({
               endReason: 'ERROR',
-              endTimestamp: trueTime.timestamp(
+              endTimestamp: timestamps.get(
                 'streaming_metrics:drm_license_fetch:endTimestamp',
+                failedSessionId,
               ),
               errorCode,
               errorMessage: JSON.stringify(error),
-              startTimestamp: trueTime.timestamp(
+              startTimestamp: timestamps.get(
                 'streaming_metrics:drm_license_fetch:startTimestamp',
+                failedSessionId,
               ),
               streamingSessionId: failedSessionId,
             }),
           ]).catch(console.error);
+
+          timestamps.clear(
+            'streaming_metrics:drm_license_fetch:endTimestamp',
+            failedSessionId,
+          );
+          timestamps.clear(
+            'streaming_metrics:drm_license_fetch:startTimestamp',
+            failedSessionId,
+          );
         }
         break;
       }


### PR DESCRIPTION
## Summary
- replace shared browser Performance API marks for streaming metrics with session-scoped in-memory timestamps
- keep playback info/statistics timestamps scoped by streaming session id without throwing into playback
- tie DRM license fetch metrics to Shaka's original request so the response/error event uses the same request-time streaming session id and start timestamp

## Root cause
The DRM license request/response filters used shared Performance API mark names such as `streaming_metrics:drm_license_fetch:startTimestamp`. When tracks were skipped quickly, one session could clear or overwrite marks while another license response filter was still running. We verified locally that when the Performance API / timestamp lookup path throws inside the DRM license filter, Shaka wraps it as inner 1007 / outer 6007 even though the network request itself succeeded.

One subtle part of the fix is that the response filter must not recompute `streamingSessionId` from mutable player state. The request may have been made for one session, while by response time `currentStreamingSessionId` / `preloadedStreamingSessionId` may point at another. The DRM metric is now captured at request time and recovered from `response.originalRequest`, so emitted `drm_license_fetch` events retain plausible request/response timestamps and the correct request session.

## Validation
- `pnpm --filter @tidal-music/player typecheck`
- `pnpm --dir packages/player exec eslint src/internal/helpers/streaming-metrics-timestamps.ts src/player/shakaPlayer.ts src/player/basePlayer.ts src/player/nativePlayer.ts src/internal/handlers/load.ts src/internal/helpers/playback-info-resolver.ts` (warnings only, pre-existing style warnings)
- rebuilt `@tidal-music/player` and refreshed local webclient file install for manual verification
