### PR TITLE
Address playback_info_fetch error reporting

### DIFF
--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -1,8 +1,56 @@
+import * as EventProducer from '@tidal-music/event-producer';
 import { expect } from 'chai';
 
-import { authAndEvents, credentialsProvider } from '../../test-helpers.js';
+import * as Player from '../../index.js';
+import {
+  authAndEvents,
+  credentialsProvider,
+  waitFor,
+} from '../../test-helpers.js';
 
 import { fetchPlaybackInfo } from './playback-info-resolver.js';
+
+type CapturedEvent = Parameters<typeof EventProducer.sendEvent>[0];
+
+/**
+ * Replace the player's event sender with a spy that records every committed
+ * event. The caller must restore the real sender afterwards.
+ */
+function spyOnCommittedEvents(): Array<CapturedEvent> {
+  const capturedEvents: Array<CapturedEvent> = [];
+
+  Player.setEventSender({
+    ...EventProducer,
+    sendEvent: (event: CapturedEvent) => {
+      capturedEvents.push(event);
+    },
+  });
+
+  return capturedEvents;
+}
+
+/**
+ * commit() is fire-and-forget inside fetchPlaybackInfo's finally block, so poll
+ * the captured events until the playback_info_fetch event(s) for this session
+ * arrive, then return them.
+ */
+async function committedPlaybackInfoFetchEvents(
+  capturedEvents: Array<CapturedEvent>,
+  streamingSessionId: string,
+): Promise<Array<CapturedEvent>> {
+  const matches = () =>
+    capturedEvents.filter(
+      event =>
+        event.name === 'playback_info_fetch' &&
+        event.payload.streamingSessionId === streamingSessionId,
+    );
+
+  for (let attempt = 0; attempt < 50 && matches().length === 0; attempt++) {
+    await waitFor(100);
+  }
+
+  return matches();
+}
 
 describe('playbackInfoResolver', () => {
   authAndEvents(before, after);
@@ -218,5 +266,127 @@ describe('playbackInfoResolver', () => {
       representationCount,
       'Non-ABR manifest should contain exactly one quality representation',
     ).to.equal(1);
+  });
+
+  // Regression: a fetch failure must commit endReason: 'ERROR'. The error
+  // fields were previously emitted via a fire-and-forget reducer call that
+  // raced (and lost to) the committed event, so failures surfaced as COMPLETE.
+  it('reports endReason ERROR in the committed playback_info_fetch event when the fetch fails', async () => {
+    const { clientId, token } = await credentialsProvider.getCredentials();
+
+    if (!token) {
+      throw new Error('No access token, cannot fulfill test.');
+    }
+
+    const capturedEvents = spyOnCommittedEvents();
+
+    // eslint-disable-next-line no-restricted-syntax
+    const streamingSessionId = `tidal-player-js-test-error-${Date.now()}`;
+
+    try {
+      let didThrow = false;
+
+      try {
+        await fetchPlaybackInfo({
+          accessToken: token,
+          audioAdaptiveBitrateStreaming: true,
+          audioQuality: 'LOSSLESS',
+          clientId,
+          // A non-existent track id returns a 4xx, which the API client does
+          // not retry, so the error path is hit quickly and deterministically.
+          mediaProduct: {
+            productId: '99999999999',
+            productType: 'track',
+            sourceId: '',
+            sourceType: '',
+          },
+          playerType: 'shaka',
+          prefetch: false,
+          streamingSessionId,
+        });
+      } catch {
+        didThrow = true;
+      }
+
+      expect(
+        didThrow,
+        'fetchPlaybackInfo should reject when the fetch fails',
+      ).to.equal(true);
+
+      const events = await committedPlaybackInfoFetchEvents(
+        capturedEvents,
+        streamingSessionId,
+      );
+      const [playbackInfoFetchEvent] = events;
+
+      expect(
+        events,
+        'exactly one playback_info_fetch event should be committed',
+      ).to.have.lengthOf(1);
+
+      if (!playbackInfoFetchEvent) {
+        throw new Error('playback_info_fetch event was never committed.');
+      }
+
+      expect(playbackInfoFetchEvent.payload.endReason).to.equal('ERROR');
+      expect(playbackInfoFetchEvent.payload.errorCode).to.be.a('string');
+    } finally {
+      // Restore the real event sender for the remaining tests.
+      Player.setEventSender(EventProducer);
+    }
+  });
+
+  // Symmetric guard for the regression above: a successful fetch must commit a
+  // single playback_info_fetch event with endReason: 'COMPLETE' and no error.
+  it('reports endReason COMPLETE in the committed playback_info_fetch event on a successful fetch', async () => {
+    const { clientId, token } = await credentialsProvider.getCredentials();
+
+    if (!token) {
+      throw new Error('No access token, cannot fulfill test.');
+    }
+
+    const capturedEvents = spyOnCommittedEvents();
+
+    // eslint-disable-next-line no-restricted-syntax
+    const streamingSessionId = `tidal-player-js-test-complete-${Date.now()}`;
+
+    try {
+      await fetchPlaybackInfo({
+        accessToken: token,
+        audioAdaptiveBitrateStreaming: true,
+        audioQuality: 'LOSSLESS',
+        clientId,
+        mediaProduct: {
+          productId: '1316405',
+          productType: 'track',
+          sourceId: '',
+          sourceType: '',
+        },
+        playerType: 'shaka',
+        prefetch: false,
+        streamingSessionId,
+      });
+
+      const events = await committedPlaybackInfoFetchEvents(
+        capturedEvents,
+        streamingSessionId,
+      );
+      const [playbackInfoFetchEvent] = events;
+
+      expect(
+        events,
+        'exactly one playback_info_fetch event should be committed',
+      ).to.have.lengthOf(1);
+
+      if (!playbackInfoFetchEvent) {
+        throw new Error('playback_info_fetch event was never committed.');
+      }
+
+      expect(playbackInfoFetchEvent.payload.endReason).to.equal('COMPLETE');
+      expect(playbackInfoFetchEvent.payload.errorCode).to.equal(null);
+    } finally {
+      // Restore the real event sender for the remaining tests.
+      Player.setEventSender(EventProducer);
+    }
   });
 });

--- a/packages/player/src/internal/helpers/playback-info-resolver.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.ts
@@ -500,6 +500,7 @@ async function _fetchVideoManifest(options: Options): Promise<PlaybackInfo> {
 export async function fetchPlaybackInfo(options: Options) {
   const { streamingSessionId } = options;
   const events = [];
+  let fetchError: Error | undefined;
 
   timestamps.mark(
     'streaming_metrics:playback_info_fetch:startTimestamp',
@@ -520,11 +521,6 @@ export async function fetchPlaybackInfo(options: Options) {
     if (playbackInfo === undefined) {
       throw new Error('Playback info was fetched, but undefined.');
     }
-
-    StreamingMetrics.playbackInfoFetch({
-      endReason: 'COMPLETE',
-      streamingSessionId,
-    }).catch(console.error);
 
     const hasAds = 'adInfo' in playbackInfo;
 
@@ -565,12 +561,10 @@ export async function fetchPlaybackInfo(options: Options) {
       streamingSessionId,
     );
 
-    StreamingMetrics.playbackInfoFetch({
-      endReason: 'ERROR',
-      errorCode: (e as Error | PlayerError).message,
-      errorMessage: (e as Error | PlayerError).stack,
-      streamingSessionId,
-    }).catch(console.error);
+    // Stash the error for the single committed event in `finally`. Emitting it
+    // here as a separate fire-and-forget reducer call raced (and lost to) that
+    // event's read-modify-write, so errors surfaced as COMPLETE.
+    fetchError = e instanceof Error ? e : new Error(String(e));
 
     events.push(
       StreamingMetrics.streamingSessionEnd({
@@ -587,10 +581,13 @@ export async function fetchPlaybackInfo(options: Options) {
   } finally {
     events.push(
       StreamingMetrics.playbackInfoFetch({
+        endReason: fetchError ? 'ERROR' : 'COMPLETE',
         endTimestamp: timestamps.get(
           'streaming_metrics:playback_info_fetch:endTimestamp',
           streamingSessionId,
         ),
+        errorCode: fetchError?.message ?? null,
+        errorMessage: fetchError?.stack ?? null,
         startTimestamp: timestamps.get(
           'streaming_metrics:playback_info_fetch:startTimestamp',
           streamingSessionId,


### PR DESCRIPTION
This PR attempts fixing the incorrect error reporting for the streaming_metrics:playback_info_fetch event. 
Failed requests are now correctly committed with endReason: 'ERROR' instead of being overwritten or raced into COMPLETE. It also adds regression tests covering both failure and success scenarios.