### PR TITLE
Automatic Tidal API module update to v1.10.44 - 2 files changed

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] - 2026-06-25
+
+### Changed
+
+- Sync to new API definitions (version: 1.10.44)
+
 ## [0.32.0] - 2026-06-25
 
 ### Changed

--- a/packages/api/bin/tidal-api-oas.json
+++ b/packages/api/bin/tidal-api-oas.json
@@ -8,7 +8,7 @@
     "description" : "The TIDAL API is a [JSON:API](https://jsonapi.org/)–compliant web API that exposes TIDAL’s music, metadata, and user-related functionality through a consistent, resource-oriented design. More information and API management are available at [developer.tidal.com](https://developer.tidal.com)",
     "termsOfService" : "https://developer.tidal.com/documentation/guidelines/guidelines-overview",
     "title" : "TIDAL API",
-    "version" : "1.10.43"
+    "version" : "1.10.44"
   },
   "externalDocs" : {
     "description" : "TIDAL Developer - Documentation",
@@ -8071,8 +8071,9 @@
       "get" : {
         "description" : "Retrieves multiple dynamicModules by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
           "in" : "query",
-          "name" : "refreshId",
+          "name" : "refreshSeed",
           "required" : false,
           "schema" : {
             "type" : "string"
@@ -8211,8 +8212,9 @@
             "type" : "string"
           }
         }, {
+          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
           "in" : "query",
-          "name" : "refreshId",
+          "name" : "refreshSeed",
           "required" : false,
           "schema" : {
             "type" : "string"
@@ -8340,8 +8342,9 @@
             "type" : "string"
           }
         }, {
+          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
           "in" : "query",
-          "name" : "refreshId",
+          "name" : "refreshSeed",
           "required" : false,
           "schema" : {
             "type" : "string"
@@ -8468,8 +8471,9 @@
       "get" : {
         "description" : "Retrieves multiple dynamicPages by available filters, or without if applicable.",
         "parameters" : [ {
+          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
           "in" : "query",
-          "name" : "refreshId",
+          "name" : "refreshSeed",
           "required" : false,
           "schema" : {
             "type" : "string"
@@ -8523,8 +8527,8 @@
             "type" : "string"
           }
         }, {
-          "description" : "Allows the client to customize which related resources should be returned. Available options: dynamicModules, subject",
-          "example" : "dynamicModules",
+          "description" : "Allows the client to customize which related resources should be returned. Available options: modules, subject",
+          "example" : "modules",
           "in" : "query",
           "name" : "include",
           "required" : false,
@@ -8532,7 +8536,7 @@
             "type" : "array",
             "items" : {
               "type" : "string",
-              "example" : "dynamicModules"
+              "example" : "modules"
             }
           }
         }, {
@@ -8606,9 +8610,9 @@
         }
       }
     },
-    "/dynamicPages/{id}/relationships/dynamicModules" : {
+    "/dynamicPages/{id}/relationships/modules" : {
       "get" : {
-        "description" : "Retrieves dynamicModules relationship.",
+        "description" : "Retrieves modules relationship.",
         "parameters" : [ {
           "description" : "DynamicPages Id",
           "example" : "nejMcAhh5N8S3EQ4LaqysVdI0cZZ",
@@ -8619,8 +8623,9 @@
             "type" : "string"
           }
         }, {
+          "description" : "Stable seed used to keep dynamic page and module results consistent across a client session.",
           "in" : "query",
-          "name" : "refreshId",
+          "name" : "refreshSeed",
           "required" : false,
           "schema" : {
             "type" : "string"
@@ -8682,8 +8687,8 @@
             "type" : "string"
           }
         }, {
-          "description" : "Allows the client to customize which related resources should be returned. Available options: dynamicModules",
-          "example" : "dynamicModules",
+          "description" : "Allows the client to customize which related resources should be returned. Available options: modules",
+          "example" : "modules",
           "in" : "query",
           "name" : "include",
           "required" : false,
@@ -8691,7 +8696,7 @@
             "type" : "array",
             "items" : {
               "type" : "string",
-              "example" : "dynamicModules"
+              "example" : "modules"
             }
           }
         } ],
@@ -8736,7 +8741,7 @@
         }, {
           "Authorization_Code_PKCE" : [ "r_usr" ]
         } ],
-        "summary" : "Get dynamicModules relationship (\"to-many\").",
+        "summary" : "Get modules relationship (\"to-many\").",
         "tags" : [ "dynamicPages" ],
         "x-path-item-properties" : {
           "required-access-tier" : "INTERNAL"
@@ -31265,11 +31270,11 @@
           "icons" : {
             "type" : "array",
             "description" : "Type of icons the module should show",
-            "example" : "SPOTLIGHT_ICON",
+            "example" : "SPOTLIGHT_INFO",
             "items" : {
               "type" : "string",
               "description" : "Type of icons the module should show",
-              "example" : "SPOTLIGHT_ICON",
+              "example" : "SPOTLIGHT_INFO",
               "enum" : [ "SPOTLIGHT_INFO", "UNKNOWN" ]
             }
           },
@@ -31434,7 +31439,7 @@
       },
       "DynamicPages_Relationships" : {
         "properties" : {
-          "dynamicModules" : {
+          "modules" : {
             "$ref" : "#/components/schemas/Multi_Relationship_Data_Document"
           },
           "subject" : {
@@ -31454,6 +31459,9 @@
             "description" : "Resource id",
             "example" : "12345"
           },
+          "meta" : {
+            "$ref" : "#/components/schemas/DynamicPages_Resource_Object_Meta"
+          },
           "relationships" : {
             "$ref" : "#/components/schemas/DynamicPages_Relationships"
           },
@@ -31462,6 +31470,16 @@
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
+          }
+        }
+      },
+      "DynamicPages_Resource_Object_Meta" : {
+        "type" : "object",
+        "properties" : {
+          "redactionReason" : {
+            "type" : "string",
+            "description" : "Reason why data has been redacted on this page",
+            "enum" : [ "NO_BIRTHDAY", "MINOR" ]
           }
         }
       },
@@ -36058,11 +36076,23 @@
             "description" : "Resource id",
             "example" : "12345"
           },
+          "meta" : {
+            "$ref" : "#/components/schemas/Terms_Resource_Object_Meta"
+          },
           "type" : {
             "minLength" : 1,
             "type" : "string",
             "description" : "Resource type",
             "example" : "tracks"
+          }
+        }
+      },
+      "Terms_Resource_Object_Meta" : {
+        "required" : [ "isLatestVersion" ],
+        "type" : "object",
+        "properties" : {
+          "isLatestVersion" : {
+            "type" : "boolean"
           }
         }
       },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/api",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "type": "module",
   "files": [
     "dist"

--- a/packages/api/src/allAPI.generated.ts
+++ b/packages/api/src/allAPI.generated.ts
@@ -5565,7 +5565,8 @@ export interface paths {
         get: {
             parameters: {
                 query: {
-                    refreshId?: string;
+                    /** @description Stable seed used to keep dynamic page and module results consistent across a client session. */
+                    refreshSeed?: string;
                     /**
                      * @description ISO 3166-1 alpha-2 country code
                      * @example US
@@ -5646,7 +5647,8 @@ export interface paths {
         get: {
             parameters: {
                 query: {
-                    refreshId?: string;
+                    /** @description Stable seed used to keep dynamic page and module results consistent across a client session. */
+                    refreshSeed?: string;
                     /**
                      * @description ISO 3166-1 alpha-2 country code
                      * @example US
@@ -5731,7 +5733,8 @@ export interface paths {
         get: {
             parameters: {
                 query: {
-                    refreshId?: string;
+                    /** @description Stable seed used to keep dynamic page and module results consistent across a client session. */
+                    refreshSeed?: string;
                     /** @description Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified */
                     "page[cursor]"?: string;
                     /**
@@ -5818,7 +5821,8 @@ export interface paths {
         get: {
             parameters: {
                 query: {
-                    refreshId?: string;
+                    /** @description Stable seed used to keep dynamic page and module results consistent across a client session. */
+                    refreshSeed?: string;
                     /**
                      * @description ISO 3166-1 alpha-2 country code
                      * @example US
@@ -5845,8 +5849,8 @@ export interface paths {
                      */
                     clientVersion: string;
                     /**
-                     * @description Allows the client to customize which related resources should be returned. Available options: dynamicModules, subject
-                     * @example dynamicModules
+                     * @description Allows the client to customize which related resources should be returned. Available options: modules, subject
+                     * @example modules
                      */
                     include?: string[];
                     /** @description type of the page (e.g. `ARTIST`) */
@@ -5887,7 +5891,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/dynamicPages/{id}/relationships/dynamicModules": {
+    "/dynamicPages/{id}/relationships/modules": {
         parameters: {
             query?: never;
             header?: never;
@@ -5895,13 +5899,14 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get dynamicModules relationship ("to-many").
-         * @description Retrieves dynamicModules relationship.
+         * Get modules relationship ("to-many").
+         * @description Retrieves modules relationship.
          */
         get: {
             parameters: {
                 query: {
-                    refreshId?: string;
+                    /** @description Stable seed used to keep dynamic page and module results consistent across a client session. */
+                    refreshSeed?: string;
                     /** @description Server-generated cursor value pointing a certain page of items. Optional, targets first page if not specified */
                     "page[cursor]"?: string;
                     /**
@@ -5930,8 +5935,8 @@ export interface paths {
                      */
                     clientVersion: string;
                     /**
-                     * @description Allows the client to customize which related resources should be returned. Available options: dynamicModules
-                     * @example dynamicModules
+                     * @description Allows the client to customize which related resources should be returned. Available options: modules
+                     * @example modules
                      */
                     include?: string[];
                 };
@@ -20542,7 +20547,7 @@ export interface components {
         DynamicModules_Attributes: {
             /**
              * @description Type of icons the module should show
-             * @example SPOTLIGHT_ICON
+             * @example SPOTLIGHT_INFO
              */
             icons: ("SPOTLIGHT_INFO" | "UNKNOWN")[];
             /**
@@ -20625,7 +20630,7 @@ export interface components {
             links: components["schemas"]["Links"];
         };
         DynamicPages_Relationships: {
-            dynamicModules?: components["schemas"]["Multi_Relationship_Data_Document"];
+            modules?: components["schemas"]["Multi_Relationship_Data_Document"];
             subject?: components["schemas"]["Single_Relationship_Data_Document"];
         };
         DynamicPages_Resource_Object: {
@@ -20635,12 +20640,20 @@ export interface components {
              * @example 12345
              */
             id: string;
+            meta?: components["schemas"]["DynamicPages_Resource_Object_Meta"];
             relationships?: components["schemas"]["DynamicPages_Relationships"];
             /**
              * @description Resource type (enum property replaced by openapi-typescript)
              * @enum {string}
              */
             type: "dynamicPages";
+        };
+        DynamicPages_Resource_Object_Meta: {
+            /**
+             * @description Reason why data has been redacted on this page
+             * @enum {string}
+             */
+            redactionReason?: "NO_BIRTHDAY" | "MINOR";
         };
         DynamicPages_Single_Relationship_Data_Document: {
             data?: components["schemas"]["Resource_Identifier"];
@@ -22519,11 +22532,15 @@ export interface components {
              * @example 12345
              */
             id: string;
+            meta?: components["schemas"]["Terms_Resource_Object_Meta"];
             /**
              * @description Resource type (enum property replaced by openapi-typescript)
              * @enum {string}
              */
             type: "terms";
+        };
+        Terms_Resource_Object_Meta: {
+            isLatestVersion: boolean;
         };
         Terms_Single_Resource_Data_Document: {
             data: components["schemas"]["Terms_Resource_Object"];


### PR DESCRIPTION
Updated Tidal API to version **v1.10.44**

**Changes in Generated file:**

M  src/allAPI.generated.ts

**Changes in Spec file:**

M  bin/tidal-api-oas.json

Also bumped `@tidal-music/api` to `0.33.0` and added the corresponding changelog entry for 2026-06-25.

Note: this was generated from the source-of-truth `tidal-engineering/tidal-api` OAS because the published API reference artifact still served v1.10.43 when this PR was created.

**Validation:**

- `packages/api/node_modules/.bin/tsc -p packages/api/tsconfig.json --noEmit`
- `packages/api/node_modules/.bin/vitest run --config packages/api/vite.config.ts packages/api/src/api.test.ts`
- `git diff --check`

This PR starts the next `@tidal-music/api` release cycle once merged.