### PR TITLE
fix(player): stop leaking native player event listeners across the contextBridge

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Native player: stopped leaking a native `mediaduration` / `mediastate` event
+  listener on every track transition. `nativeEvent` / `mediaStateChange` used
+  to add a bridge event listener per wait and remove it once the event
+  arrived, but across Electron's `contextBridge` the function handed to
+  `removeEventListener` is wrapped as a _different_ proxy than the one
+  `addEventListener` registered, so removal never matched — every wait leaked
+  a listener and its awaiting closure (including the full load payload), one
+  set per track skip, growing renderer memory unboundedly. This surfaced as
+  the `MaxListenersExceededWarning` for `mediaduration` in desktop logs and
+  contributed to renderer out-of-memory crashes on 32-bit (Windows) builds.
+  Waits are now dispatched by a single persistent listener per event type and
+  tracked in a JS-side registry with stable identity, so the native listener
+  count stays constant regardless of how many tracks are played. Pending waits
+  are still cancelled when the player is reset — freeing the awaiting closure
+  when the awaited event never arrives, e.g. because the native player process
+  crashed — and the temporary `online` listener used during network-error
+  recovery is removed once the recovery race settles.
+
 ## [0.18.3] - 2026-06-23
 
 ### Fixed

--- a/packages/player/src/player/nativePlayer.test.ts
+++ b/packages/player/src/player/nativePlayer.test.ts
@@ -1,20 +1,17 @@
 import { expect } from 'chai';
 
+import { events } from '../event-bus.js';
+
+import type { LoadPayload } from './basePlayer.js';
 import NativePlayer, { EventWaitCancelledError } from './nativePlayer.js';
 
 type Listener = (...args: Array<unknown>) => void;
 
 /**
- * Stand-in for the native player bridge
- * (window.NativePlayerComponent.Player()).
- *
- * Critically, it models Electron's contextBridge semantics: a function passed
- * across the isolated-world boundary does NOT keep its identity, so the bridge
- * can never find the wrapper it created for an earlier addEventListener when
- * removeEventListener is later called with the "same" function. We reproduce
- * that by making removeEventListener a no-op. A correct SDK must therefore not
- * rely on removeEventListener to bound its listener count — which is exactly
- * the leak these tests guard against.
+ * Stand-in for the native player bridge. Models Electron's contextBridge
+ * semantics — a function loses its identity across the boundary, so
+ * removeEventListener can never match its addEventListener — by making
+ * removeEventListener a no-op. This is the leak these tests guard against.
  */
 class NativePlayerComponentMock {
   listeners = new Map<string, Array<Listener>>();
@@ -52,8 +49,7 @@ class NativePlayerComponentMock {
 
   releaseDevice() {}
 
-  // No-op on purpose: see the class comment. The contextBridge cannot match
-  // the listener, so removal never happens across the real bridge.
+  // No-op on purpose: see the class comment.
   removeEventListener() {}
 
   seek() {}
@@ -70,9 +66,7 @@ class NativePlayerComponentMock {
 describe('NativePlayer pending event waits', () => {
   let bridge: NativePlayerComponentMock;
   let player: NativePlayer;
-  // Listeners registered by the NativePlayer constructor itself
-  // (registerEventListeners); the waits under test add at most one dispatcher
-  // per event type on top of these.
+  // Listeners the constructor registers; waits add at most one dispatcher per event type on top.
   let baselineMediaduration: number;
   let baselineMediastate: number;
 
@@ -129,10 +123,8 @@ describe('NativePlayer pending event waits', () => {
   });
 
   it('registers at most one bridge listener per event type when waits resolve', async () => {
-    // Even though removeEventListener is a no-op across the contextBridge, the
-    // SDK must not add a bridge listener per wait. It registers a single
-    // persistent dispatcher per event type and routes each transient waiter
-    // through a JS-side collection instead.
+    // The SDK must register one persistent dispatcher per event type, not one
+    // bridge listener per wait (removeEventListener is a no-op across the bridge).
     for (let i = 0; i < 25; i += 1) {
       const durationWait = player.nativeEvent('mediaduration');
       const stateWait = player.mediaStateChange('active');
@@ -150,10 +142,8 @@ describe('NativePlayer pending event waits', () => {
   });
 
   it('does not accumulate bridge listeners across repeated waits and resets', async () => {
-    // Simulates repeated track transitions while the native player never
-    // answers (e.g. after the player process crashed): every load awaits
-    // mediaduration/mediastate events that never arrive, and reset() flushes
-    // them. The bridge listener count must stay bounded regardless.
+    // Repeated transitions where the native events never arrive and reset()
+    // flushes the pending waits. The bridge listener count must stay bounded.
     for (let i = 0; i < 25; i += 1) {
       const durationWait = player.nativeEvent('mediaduration');
       const stateWait = player.mediaStateChange('active');
@@ -189,5 +179,50 @@ describe('NativePlayer pending event waits', () => {
     const freshResult = await freshWait;
 
     expect((freshResult as unknown as { target: number }).target).to.equal(42);
+  });
+
+  it('load() swallows the cancellation when a reset interrupts its duration wait', async () => {
+    const transitions: Array<Event> = [];
+    const onTransition = (event: Event) => transitions.push(event);
+
+    events.addEventListener('media-product-transition', onTransition);
+
+    const payload = {
+      assetPosition: 0,
+      mediaProduct: {},
+      playbackInfo: {},
+      streamInfo: {
+        expires: 3600000,
+        id: 'stream-1',
+        prefetched: false,
+        quality: 'LOSSLESS',
+        securityToken: 'token',
+        streamFormat: 'flac',
+        streamUrl: 'https://example.com/stream',
+        streamingSessionId: 'session-1',
+        type: 'track',
+      },
+    } as unknown as LoadPayload;
+
+    try {
+      const loadPromise = player.load(payload, 'implicit');
+
+      // Let load() get past its initial reset() and register the mediaduration
+      // wait before we interrupt it (the native event never arrives).
+      await new Promise(resolve => {
+        setTimeout(resolve);
+      });
+
+      await player.reset();
+
+      // load() must resolve rather than surface the cancellation as an
+      // unhandled rejection...
+      await loadPromise;
+
+      // ...and must not dispatch a transition for the abandoned media product.
+      expect(transitions).to.have.length(0);
+    } finally {
+      events.removeEventListener('media-product-transition', onTransition);
+    }
   });
 });

--- a/packages/player/src/player/nativePlayer.test.ts
+++ b/packages/player/src/player/nativePlayer.test.ts
@@ -1,0 +1,193 @@
+import { expect } from 'chai';
+
+import NativePlayer, { EventWaitCancelledError } from './nativePlayer.js';
+
+type Listener = (...args: Array<unknown>) => void;
+
+/**
+ * Stand-in for the native player bridge
+ * (window.NativePlayerComponent.Player()).
+ *
+ * Critically, it models Electron's contextBridge semantics: a function passed
+ * across the isolated-world boundary does NOT keep its identity, so the bridge
+ * can never find the wrapper it created for an earlier addEventListener when
+ * removeEventListener is later called with the "same" function. We reproduce
+ * that by making removeEventListener a no-op. A correct SDK must therefore not
+ * rely on removeEventListener to bound its listener count — which is exactly
+ * the leak these tests guard against.
+ */
+class NativePlayerComponentMock {
+  listeners = new Map<string, Array<Listener>>();
+
+  addEventListener(eventName: string, listener: Listener) {
+    const list = this.listeners.get(eventName) ?? [];
+
+    list.push(listener);
+    this.listeners.set(eventName, list);
+  }
+
+  cancelPreload() {}
+
+  emit(eventName: string, payload: unknown) {
+    for (const listener of [...(this.listeners.get(eventName) ?? [])]) {
+      listener(payload);
+    }
+  }
+
+  listDevices() {}
+
+  listenerCount(eventName: string) {
+    return this.listeners.get(eventName)?.length ?? 0;
+  }
+
+  load() {}
+
+  pause() {}
+
+  play() {}
+
+  preload() {}
+
+  recover() {}
+
+  releaseDevice() {}
+
+  // No-op on purpose: see the class comment. The contextBridge cannot match
+  // the listener, so removal never happens across the real bridge.
+  removeEventListener() {}
+
+  seek() {}
+
+  selectDevice() {}
+
+  selectSystemDevice() {}
+
+  setVolume() {}
+
+  stop() {}
+}
+
+describe('NativePlayer pending event waits', () => {
+  let bridge: NativePlayerComponentMock;
+  let player: NativePlayer;
+  // Listeners registered by the NativePlayer constructor itself
+  // (registerEventListeners); the waits under test add at most one dispatcher
+  // per event type on top of these.
+  let baselineMediaduration: number;
+  let baselineMediastate: number;
+
+  beforeEach(() => {
+    bridge = new NativePlayerComponentMock();
+    // @ts-expect-error - Mocking window.NativePlayerComponent for tests
+    window.NativePlayerComponent = { Player: () => bridge };
+    player = new NativePlayer();
+    baselineMediaduration = bridge.listenerCount('mediaduration');
+    baselineMediastate = bridge.listenerCount('mediastate');
+  });
+
+  it('resolves nativeEvent when the event arrives', async () => {
+    const wait = player.nativeEvent('mediaduration');
+
+    bridge.emit('mediaduration', { target: 100 });
+
+    const event = (await wait) as unknown as { target: number };
+
+    expect(event.target).to.equal(100);
+  });
+
+  it('resolves mediaStateChange only for the requested state', async () => {
+    const wait = player.mediaStateChange('active');
+    let settled = false;
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    wait.then(() => {
+      settled = true;
+    });
+
+    bridge.emit('mediastate', { target: 'stalled' });
+    await Promise.resolve();
+    expect(settled).to.equal(false);
+
+    bridge.emit('mediastate', { target: 'active' });
+    expect(await wait).to.equal('active');
+  });
+
+  it('rejects pending waits on reset with EventWaitCancelledError', async () => {
+    const durationWait = player.nativeEvent('mediaduration');
+    const stateWait = player.mediaStateChange('active');
+
+    await player.reset();
+
+    const results = await Promise.allSettled([durationWait, stateWait]);
+
+    for (const result of results) {
+      expect(result.status).to.equal('rejected');
+      expect((result as PromiseRejectedResult).reason).to.be.an.instanceOf(
+        EventWaitCancelledError,
+      );
+    }
+  });
+
+  it('registers at most one bridge listener per event type when waits resolve', async () => {
+    // Even though removeEventListener is a no-op across the contextBridge, the
+    // SDK must not add a bridge listener per wait. It registers a single
+    // persistent dispatcher per event type and routes each transient waiter
+    // through a JS-side collection instead.
+    for (let i = 0; i < 25; i += 1) {
+      const durationWait = player.nativeEvent('mediaduration');
+      const stateWait = player.mediaStateChange('active');
+
+      bridge.emit('mediaduration', { target: i });
+      bridge.emit('mediastate', { target: 'active' });
+
+      await Promise.all([durationWait, stateWait]);
+    }
+
+    expect(bridge.listenerCount('mediaduration')).to.equal(
+      baselineMediaduration + 1,
+    );
+    expect(bridge.listenerCount('mediastate')).to.equal(baselineMediastate + 1);
+  });
+
+  it('does not accumulate bridge listeners across repeated waits and resets', async () => {
+    // Simulates repeated track transitions while the native player never
+    // answers (e.g. after the player process crashed): every load awaits
+    // mediaduration/mediastate events that never arrive, and reset() flushes
+    // them. The bridge listener count must stay bounded regardless.
+    for (let i = 0; i < 25; i += 1) {
+      const durationWait = player.nativeEvent('mediaduration');
+      const stateWait = player.mediaStateChange('active');
+
+      await player.reset();
+
+      const results = await Promise.allSettled([durationWait, stateWait]);
+
+      expect(results.every(result => result.status === 'rejected')).to.equal(
+        true,
+      );
+    }
+
+    expect(bridge.listenerCount('mediaduration')).to.equal(
+      baselineMediaduration + 1,
+    );
+    expect(bridge.listenerCount('mediastate')).to.equal(baselineMediastate + 1);
+  });
+
+  it('leaves waits created after a reset untouched', async () => {
+    const staleWait = player.nativeEvent('mediaduration');
+
+    await player.reset();
+
+    const freshWait = player.nativeEvent('mediaduration');
+
+    expect((await Promise.allSettled([staleWait]))[0]?.status).to.equal(
+      'rejected',
+    );
+
+    bridge.emit('mediaduration', { target: 42 });
+
+    const freshResult = await freshWait;
+
+    expect((freshResult as unknown as { target: number }).target).to.equal(42);
+  });
+});

--- a/packages/player/src/player/nativePlayer.ts
+++ b/packages/player/src/player/nativePlayer.ts
@@ -61,9 +61,39 @@ const deviceErrorCodeMap: Record<DeviceErrorNames, ErrorCodes> = {
 
 let outputDevices: OutputDevices | undefined;
 
+/**
+ * A pending JS-side waiter for a native player event. Waiters are held in a
+ * plain JS collection rather than registered individually on the native
+ * bridge, so their identity stays stable — see NativePlayer#eventWaiters for
+ * why that matters.
+ */
+type NativeEventWaiter = {
+  predicate?: (event: Event) => boolean;
+  settle: (event: Event) => void;
+};
+
+/**
+ * Rejected into pending native event waits (nativeEvent / mediaStateChange)
+ * when the player is reset before the awaited event arrives. Callers treat it
+ * as "this wait is obsolete" and bail out instead of continuing with state
+ * that belongs to a previous media product.
+ */
+export class EventWaitCancelledError extends Error {
+  constructor(eventName: string) {
+    super(`Wait for native player event '${eventName}' was cancelled.`);
+    this.name = 'EventWaitCancelledError';
+  }
+}
+
 // eslint-disable-next-line import/no-default-export
 export default class NativePlayer extends BasePlayer {
   #currentOutputId = 'default';
+
+  /**
+   * Event types for which the single persistent bridge dispatcher has already
+   * been registered (see #ensureEventDispatcher).
+   */
+  #dispatchedEvents = new Set<NativePlayerComponentSupportedEvents>();
 
   /**
    * A Boolean which is true if the media contained in the element has finished playing.
@@ -76,6 +106,34 @@ export default class NativePlayer extends BasePlayer {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/ended
    */
   #duration!: number;
+
+  /**
+   * Transient waiters for native player events, keyed by event name, resolved
+   * by the per-event dispatcher registered in #ensureEventDispatcher.
+   *
+   * Waiters live here, on the JS side, rather than as individual bridge
+   * listeners because Electron's contextBridge does not preserve function
+   * reference identity across the isolated-world boundary: the wrapper it
+   * creates for a listener passed to removeEventListener differs from the one
+   * created for the matching addEventListener, so removeEventListener never
+   * matches and every transient bridge listener would leak — one per media
+   * product transition, for the lifetime of the app. Registering a single
+   * persistent dispatcher per event type and fanning out to these
+   * identity-stable waiters keeps the native listener count constant.
+   */
+  #eventWaiters = new Map<
+    NativePlayerComponentSupportedEvents,
+    Set<NativeEventWaiter>
+  >();
+
+  /**
+   * Cancel callbacks for event waits that have not settled yet. Without this
+   * registry, a wait whose event never arrives (e.g. because the native
+   * player process died) keeps the closure of the awaiting call — including
+   * the full load payload — alive for the lifetime of the app, one set per
+   * media product transition.
+   */
+  #pendingEventWaits = new Set<() => void>();
 
   #player!: NativePlayerComponentInterface;
 
@@ -107,6 +165,40 @@ export default class NativePlayer extends BasePlayer {
 
     this.registerEventListeners();
     this.#player.setVolume(100);
+  }
+
+  #cancelPendingEventWaits() {
+    for (const cancel of [...this.#pendingEventWaits]) {
+      cancel();
+    }
+  }
+
+  /**
+   * Register exactly one persistent bridge listener per event type. It is
+   * added once and never removed (removal across the contextBridge is a no-op
+   * — see #eventWaiters), which keeps the native listener count bounded. The
+   * listener fans each native event out to any JS-side waiters for that type.
+   */
+  #ensureEventDispatcher(eventName: NativePlayerComponentSupportedEvents) {
+    if (this.#dispatchedEvents.has(eventName)) {
+      return;
+    }
+
+    this.#dispatchedEvents.add(eventName);
+    this.#player.addEventListener(eventName, (event: Event) => {
+      const waiters = this.#eventWaiters.get(eventName);
+
+      if (!waiters?.size) {
+        return;
+      }
+
+      // Copy before iterating: settle() removes the waiter from the set.
+      for (const waiter of [...waiters]) {
+        if (!waiter.predicate || waiter.predicate(event)) {
+          waiter.settle(event);
+        }
+      }
+    });
   }
 
   #handleDeviceError(errorName: DeviceErrorNames) {
@@ -192,16 +284,80 @@ export default class NativePlayer extends BasePlayer {
       If we go online before playback stops; do nothing = native player retries and recovers.
       If playback stops without an online event emitting = emit error.
     */
-    const raceResult = await Promise.race([
-      this.mediaStateChange('idle') as Promise<'idle'>,
-      new Promise<'online'>(resolve => {
-        window.addEventListener('online', () => resolve('online'));
-      }),
-    ]);
+    const onlineListenerAbort = new AbortController();
+    let raceResult: 'idle' | 'online';
+
+    try {
+      raceResult = await Promise.race([
+        this.mediaStateChange('idle') as Promise<'idle'>,
+        new Promise<'online'>(resolve => {
+          window.addEventListener('online', () => resolve('online'), {
+            once: true,
+            signal: onlineListenerAbort.signal,
+          });
+        }),
+      ]);
+    } catch (error) {
+      if (error instanceof EventWaitCancelledError) {
+        // Player was reset while waiting; nothing left to report.
+        return;
+      }
+
+      throw error;
+    } finally {
+      // Whichever way the race settles, do not leave the online listener
+      // on window forever.
+      onlineListenerAbort.abort();
+    }
 
     if (raceResult === 'idle') {
       events.dispatchError(new PlayerError('PENetwork', 'NPN01'));
     }
+  }
+
+  /**
+   * Wait for the next native player event of a given type, optionally
+   * filtered by a predicate. The waiter is dispatched by the persistent
+   * per-type bridge listener (see #ensureEventDispatcher) and registered in
+   * #pendingEventWaits so that reset() can cancel it (rejecting with
+   * {@link EventWaitCancelledError}) instead of leaving the awaiting closure
+   * dangling forever when the event never arrives.
+   */
+  #waitForPlayerEvent<T extends Event>(
+    eventName: NativePlayerComponentSupportedEvents,
+    predicate?: (event: T) => boolean,
+  ): Promise<T> {
+    this.#ensureEventDispatcher(eventName);
+
+    return new Promise<T>((resolve, reject) => {
+      const existing = this.#eventWaiters.get(eventName);
+      const waiters = existing ?? new Set<NativeEventWaiter>();
+
+      if (!existing) {
+        this.#eventWaiters.set(eventName, waiters);
+      }
+
+      const cleanup = () => {
+        waiters.delete(waiter);
+        this.#pendingEventWaits.delete(cancel);
+      };
+
+      const waiter: NativeEventWaiter = {
+        predicate: predicate as ((event: Event) => boolean) | undefined,
+        settle: (event: Event) => {
+          cleanup();
+          resolve(event as T);
+        },
+      };
+
+      const cancel = () => {
+        cleanup();
+        reject(new EventWaitCancelledError(eventName));
+      };
+
+      waiters.add(waiter);
+      this.#pendingEventWaits.add(cancel);
+    });
   }
 
   /**
@@ -229,7 +385,16 @@ export default class NativePlayer extends BasePlayer {
    * can gather the duration data and send a media product transition.
    */
   async handleAutomaticTransitionToPreloadedMediaProduct() {
-    await this.nativeEvent('mediaduration');
+    try {
+      await this.nativeEvent('mediaduration');
+    } catch (error) {
+      if (error instanceof EventWaitCancelledError) {
+        // Player was reset while waiting; the transition is obsolete.
+        return;
+      }
+
+      throw error;
+    }
 
     this.#preloadedLoadPayload = undefined;
 
@@ -264,7 +429,17 @@ export default class NativePlayer extends BasePlayer {
       );
     }
 
-    await this.mediaStateChange('active');
+    try {
+      await this.mediaStateChange('active');
+    } catch (error) {
+      if (error instanceof EventWaitCancelledError) {
+        // Player was reset while waiting; do not dispatch a transition for
+        // a media product that is no longer current.
+        return;
+      }
+
+      throw error;
+    }
 
     events.dispatchEvent(
       mediaProductTransitionEvent(mediaProduct, updatedPlaybackContext),
@@ -300,7 +475,16 @@ export default class NativePlayer extends BasePlayer {
       throw new Error('Stream format is undefined.');
     }
 
-    await mediaDurationEventPromise;
+    try {
+      await mediaDurationEventPromise;
+    } catch (error) {
+      if (error instanceof EventWaitCancelledError) {
+        // Player was reset during load, do not continue.
+        return;
+      }
+
+      throw error;
+    }
 
     // Player was reset during load, do not continue.
     if (this.currentStreamingSessionId !== streamInfo.streamingSessionId) {
@@ -322,7 +506,13 @@ export default class NativePlayer extends BasePlayer {
           await this.seek(assetPosition);
           this.currentTime = assetPosition;
         }
-      })().catch(console.error);
+      })().catch((error: unknown) => {
+        // A cancelled wait means the player was reset before becoming
+        // active; the deferred seek is obsolete, not an error.
+        if (!(error instanceof EventWaitCancelledError)) {
+          console.error(error);
+        }
+      });
     } else {
       this.currentTime = 0;
     }
@@ -350,27 +540,14 @@ export default class NativePlayer extends BasePlayer {
   }
 
   mediaStateChange(state: string): Promise<string> {
-    return new Promise<string>(resolve => {
-      const handler = (event: Event & { target: string }) => {
-        if (event.target === state) {
-          this.#player.removeEventListener('mediastate', handler);
-          resolve(event.target);
-        }
-      };
-
-      this.#player.addEventListener('mediastate', handler);
-    });
+    return this.#waitForPlayerEvent<Event & { target: string }>(
+      'mediastate',
+      event => event.target === state,
+    ).then(event => event.target);
   }
 
   nativeEvent(eventName: NativePlayerComponentSupportedEvents): Promise<Event> {
-    return new Promise(resolve => {
-      const handler = (event: Event) => {
-        this.#player.removeEventListener(eventName, handler);
-        resolve(event);
-      };
-
-      this.#player.addEventListener(eventName, handler);
-    });
+    return this.#waitForPlayerEvent(eventName);
   }
 
   async next(payload: LoadPayload) {
@@ -542,6 +719,11 @@ export default class NativePlayer extends BasePlayer {
   async reset(
     { keepPreload }: { keepPreload: boolean } = { keepPreload: false },
   ) {
+    // Settle event waits belonging to the previous media product so their
+    // listeners and closures cannot accumulate when the native player never
+    // delivers the awaited event (e.g. after the player process crashed).
+    this.#cancelPendingEventWaits();
+
     if (this.currentStreamingSessionId === undefined) {
       return;
     }
@@ -573,7 +755,16 @@ export default class NativePlayer extends BasePlayer {
   async seek(seconds: number) {
     // Native player cannot seek until active state has happened.
     if (!this.hasStarted()) {
-      await this.mediaStateChange('active');
+      try {
+        await this.mediaStateChange('active');
+      } catch (error) {
+        if (error instanceof EventWaitCancelledError) {
+          // Player was reset while waiting to become seekable; drop the seek.
+          return;
+        }
+
+        throw error;
+      }
     }
 
     this.seekStart(this.currentTime);

--- a/packages/player/src/player/nativePlayer.ts
+++ b/packages/player/src/player/nativePlayer.ts
@@ -61,23 +61,13 @@ const deviceErrorCodeMap: Record<DeviceErrorNames, ErrorCodes> = {
 
 let outputDevices: OutputDevices | undefined;
 
-/**
- * A pending JS-side waiter for a native player event. Waiters are held in a
- * plain JS collection rather than registered individually on the native
- * bridge, so their identity stays stable — see NativePlayer#eventWaiters for
- * why that matters.
- */
+/** A pending JS-side waiter for a native player event (see #eventWaiters). */
 type NativeEventWaiter = {
   predicate?: (event: Event) => boolean;
   settle: (event: Event) => void;
 };
 
-/**
- * Rejected into pending native event waits (nativeEvent / mediaStateChange)
- * when the player is reset before the awaited event arrives. Callers treat it
- * as "this wait is obsolete" and bail out instead of continuing with state
- * that belongs to a previous media product.
- */
+/** Rejected into pending event waits when the player is reset before the event arrives. */
 export class EventWaitCancelledError extends Error {
   constructor(eventName: string) {
     super(`Wait for native player event '${eventName}' was cancelled.`);
@@ -89,10 +79,7 @@ export class EventWaitCancelledError extends Error {
 export default class NativePlayer extends BasePlayer {
   #currentOutputId = 'default';
 
-  /**
-   * Event types for which the single persistent bridge dispatcher has already
-   * been registered (see #ensureEventDispatcher).
-   */
+  /** Event types that already have a persistent dispatcher (see #ensureEventDispatcher). */
   #dispatchedEvents = new Set<NativePlayerComponentSupportedEvents>();
 
   /**
@@ -108,31 +95,21 @@ export default class NativePlayer extends BasePlayer {
   #duration!: number;
 
   /**
-   * Transient waiters for native player events, keyed by event name, resolved
-   * by the per-event dispatcher registered in #ensureEventDispatcher.
+   * Transient waiters for native player events, keyed by event name, fanned out
+   * to by the per-event dispatcher in #ensureEventDispatcher.
    *
-   * Waiters live here, on the JS side, rather than as individual bridge
-   * listeners because Electron's contextBridge does not preserve function
-   * reference identity across the isolated-world boundary: the wrapper it
-   * creates for a listener passed to removeEventListener differs from the one
-   * created for the matching addEventListener, so removeEventListener never
-   * matches and every transient bridge listener would leak — one per media
-   * product transition, for the lifetime of the app. Registering a single
-   * persistent dispatcher per event type and fanning out to these
-   * identity-stable waiters keeps the native listener count constant.
+   * Waiters live on the JS side rather than as individual bridge listeners
+   * because Electron's contextBridge does not preserve function identity across
+   * the isolated-world boundary, so removeEventListener never matches its
+   * addEventListener and every transient bridge listener would leak. One
+   * persistent dispatcher per event type keeps the native listener count fixed.
    */
   #eventWaiters = new Map<
     NativePlayerComponentSupportedEvents,
     Set<NativeEventWaiter>
   >();
 
-  /**
-   * Cancel callbacks for event waits that have not settled yet. Without this
-   * registry, a wait whose event never arrives (e.g. because the native
-   * player process died) keeps the closure of the awaiting call — including
-   * the full load payload — alive for the lifetime of the app, one set per
-   * media product transition.
-   */
+  /** Cancel callbacks for unsettled event waits, so reset() can drop them instead of leaking closures. */
   #pendingEventWaits = new Set<() => void>();
 
   #player!: NativePlayerComponentInterface;
@@ -174,10 +151,9 @@ export default class NativePlayer extends BasePlayer {
   }
 
   /**
-   * Register exactly one persistent bridge listener per event type. It is
-   * added once and never removed (removal across the contextBridge is a no-op
-   * — see #eventWaiters), which keeps the native listener count bounded. The
-   * listener fans each native event out to any JS-side waiters for that type.
+   * Register exactly one persistent bridge listener per event type (never
+   * removed, since removal across the contextBridge is a no-op — see
+   * #eventWaiters) that fans each native event out to its JS-side waiters.
    */
   #ensureEventDispatcher(eventName: NativePlayerComponentSupportedEvents) {
     if (this.#dispatchedEvents.has(eventName)) {
@@ -305,8 +281,7 @@ export default class NativePlayer extends BasePlayer {
 
       throw error;
     } finally {
-      // Whichever way the race settles, do not leave the online listener
-      // on window forever.
+      // However the race settles, don't leave the online listener on window.
       onlineListenerAbort.abort();
     }
 
@@ -316,12 +291,9 @@ export default class NativePlayer extends BasePlayer {
   }
 
   /**
-   * Wait for the next native player event of a given type, optionally
-   * filtered by a predicate. The waiter is dispatched by the persistent
-   * per-type bridge listener (see #ensureEventDispatcher) and registered in
-   * #pendingEventWaits so that reset() can cancel it (rejecting with
-   * {@link EventWaitCancelledError}) instead of leaving the awaiting closure
-   * dangling forever when the event never arrives.
+   * Wait for the next native player event of a given type, optionally filtered
+   * by a predicate. reset() can cancel the wait via #pendingEventWaits,
+   * rejecting with {@link EventWaitCancelledError}.
    */
   #waitForPlayerEvent<T extends Event>(
     eventName: NativePlayerComponentSupportedEvents,
@@ -433,8 +405,7 @@ export default class NativePlayer extends BasePlayer {
       await this.mediaStateChange('active');
     } catch (error) {
       if (error instanceof EventWaitCancelledError) {
-        // Player was reset while waiting; do not dispatch a transition for
-        // a media product that is no longer current.
+        // Player was reset while waiting; the transition is obsolete.
         return;
       }
 
@@ -507,8 +478,7 @@ export default class NativePlayer extends BasePlayer {
           this.currentTime = assetPosition;
         }
       })().catch((error: unknown) => {
-        // A cancelled wait means the player was reset before becoming
-        // active; the deferred seek is obsolete, not an error.
+        // A cancelled wait means the player was reset; the seek is obsolete, not an error.
         if (!(error instanceof EventWaitCancelledError)) {
           console.error(error);
         }
@@ -719,9 +689,8 @@ export default class NativePlayer extends BasePlayer {
   async reset(
     { keepPreload }: { keepPreload: boolean } = { keepPreload: false },
   ) {
-    // Settle event waits belonging to the previous media product so their
-    // listeners and closures cannot accumulate when the native player never
-    // delivers the awaited event (e.g. after the player process crashed).
+    // Cancel waits from the previous media product so they cannot leak when
+    // the awaited native event never arrives.
     this.#cancelPendingEventWaits();
 
     if (this.currentStreamingSessionId === undefined) {


### PR DESCRIPTION
## Summary

`NativePlayer.nativeEvent` / `mediaStateChange` added a native bridge event listener for every event wait and removed it once the event arrived. Across Electron's `contextBridge`, the function handed to `removeEventListener` is wrapped as a *different* proxy than the one `addEventListener` registered, so **removal never matched** — every wait leaked a listener and its awaiting closure (including the full load payload), one set per track transition, growing the renderer heap unboundedly.

This surfaced as the `MaxListenersExceededWarning` for `mediaduration` in desktop logs and contributed to renderer out-of-memory crashes on 32-bit (Windows) builds.

## Changes

- **Single persistent dispatcher per event type.** Each event type registers exactly one bridge listener (never removed, since removal across the bridge is a no-op) that fans events out to JS-side waiters held in a registry with stable identity. The native listener count now stays constant regardless of how many tracks play.
- **Pending waits are cancelled on `reset()`.** Waits that never receive their event (e.g. after the native player process dies) reject with a new `EventWaitCancelledError` instead of leaving the awaiting closure dangling forever. Callers (`load`, `handleAutomaticTransitionToPreloadedMediaProduct`, `seek`, the deferred-seek path) treat the cancellation as "this wait is obsolete" and bail out cleanly rather than acting on state from a previous media product.
- **Network-error recovery `online` listener** is now removed once the recovery race settles, via an `AbortController`, instead of staying on `window` forever.

## Tests

The mock models `contextBridge` semantics faithfully (`removeEventListener` is a no-op), so the tests reproduce the original leak and prove the fix bounds the listener count. Coverage includes:

- `nativeEvent` / `mediaStateChange` resolve on the right event.
- Pending waits reject with `EventWaitCancelledError` on `reset()`.
- At most one bridge listener per event type across repeated resolved waits **and** across repeated waits + resets.
- Waits created after a reset are untouched.
- `load()` swallows the cancellation when a `reset()` interrupts its `mediaduration` wait — resolving instead of surfacing an unhandled rejection, and dispatching no stale media-product transition.
