### PR TITLE
fix(player): stop leaking 'ended' events on native gapless transitions

### DIFF
--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -634,9 +634,16 @@ export class BasePlayer {
     this.updateVolumeLevel();
     this.#hasEmittedPreloadRequest = false;
 
-    this.preloadedStreamingSessionId = undefined;
+    // Only clear the preload bookkeeping if it still refers to the session
+    // that just started. A replacement preload registered while the
+    // transition settled must stay tracked, otherwise it can never be
+    // cancelled and plays unannounced at the next boundary.
+    if (this.preloadedStreamingSessionId === streamingSessionId) {
+      this.preloadedStreamingSessionId = undefined;
 
-    this.unloadPreloadedMediaProduct().catch(console.error);
+      this.unloadPreloadedMediaProduct().catch(console.error);
+    }
+
     this.attachPlaybackEngineEndedHandler();
   }
 

--- a/packages/player/src/player/nativePlayer.test.ts
+++ b/packages/player/src/player/nativePlayer.test.ts
@@ -1,0 +1,238 @@
+import { expect } from 'chai';
+
+import type { EndedEvent } from '../api/event/ended.js';
+import type { MediaProductTransition } from '../api/event/media-product-transition.js';
+import type { MediaProduct, PlaybackContext } from '../api/interfaces.js';
+import { events } from '../event-bus.js';
+import type { StreamInfo } from '../internal/helpers/manifest-parser.js';
+import { streamingSessionStore } from '../internal/helpers/streaming-session-store.js';
+
+import { BasePlayer } from './basePlayer.js';
+import NativePlayer from './nativePlayer.js';
+import { playerState } from './state.js';
+
+/**
+ * Minimal stand-in for the native player component. The real component
+ * delivers events as `{ target }` objects, so we keep our own listener
+ * registry and `emit` them the same way instead of going through the DOM
+ * EventTarget (which would overwrite `event.target`).
+ */
+class MockNativeComponent {
+  #listeners = new Map<string, Set<(e: unknown) => void>>();
+
+  addEventListener(name: string, handler: (e: unknown) => void) {
+    if (!this.#listeners.has(name)) {
+      this.#listeners.set(name, new Set());
+    }
+
+    this.#listeners.get(name)?.add(handler);
+  }
+
+  cancelPreload() {}
+
+  emit(name: string, target: unknown) {
+    for (const handler of [...(this.#listeners.get(name) ?? [])]) {
+      handler({ target });
+    }
+  }
+
+  load() {}
+
+  pause() {}
+
+  play() {}
+
+  preload() {}
+
+  removeEventListener(name: string, handler: (e: unknown) => void) {
+    this.#listeners.get(name)?.delete(handler);
+  }
+
+  seek() {}
+
+  selectSystemDevice() {}
+
+  setVolume() {}
+
+  stop() {}
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+function mediaProduct(productId: string): MediaProduct {
+  return {
+    productId,
+    productType: 'track',
+    sourceId: 'tidal-player-tests',
+    sourceType: 'tidal-player-tests',
+  };
+}
+
+function playbackContext(sessionId: string): PlaybackContext {
+  return {
+    actualAssetPresentation: 'FULL',
+    actualAudioMode: 'STEREO',
+    actualAudioQuality: 'LOSSLESS',
+    actualDuration: 20,
+    actualProductId: '1',
+    actualStreamType: 'ON_DEMAND',
+    actualVideoQuality: null,
+    assetPosition: 0,
+    bandwidth: null,
+    bitDepth: 16,
+    codec: 'flac',
+    playbackSessionId: sessionId,
+    sampleRate: 44100,
+  };
+}
+
+/** Seeds the store so the session looks like a started, playing product. */
+function seedStartedProduct(sessionId: string) {
+  streamingSessionStore.saveStreamInfo(sessionId, {
+    expires: 9_999_999_999_999,
+    streamingSessionId: sessionId,
+  } as unknown as StreamInfo);
+  streamingSessionStore.saveMediaProductTransition(sessionId, {
+    mediaProduct: mediaProduct(sessionId),
+    playbackContext: playbackContext(sessionId),
+  });
+  streamingSessionStore.setStartedStreamInfo(sessionId);
+}
+
+/** Seeds the store so the session looks like a preloaded next product. */
+function seedPreloadedProduct(sessionId: string) {
+  streamingSessionStore.saveStreamInfo(sessionId, {
+    expires: 9_999_999_999_999,
+    streamingSessionId: sessionId,
+  } as unknown as StreamInfo);
+  streamingSessionStore.saveMediaProductTransition(sessionId, {
+    mediaProduct: mediaProduct(sessionId),
+    playbackContext: playbackContext(sessionId),
+  });
+}
+
+function createNativePlayer() {
+  const native = new MockNativeComponent();
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - Test mock
+  window.NativePlayerComponent = { Player: () => native };
+
+  return { native, player: new NativePlayer() };
+}
+
+describe('NativePlayer gapless transitions', () => {
+  const created: Array<string> = [];
+
+  afterEach(() => {
+    playerState.activePlayer = undefined;
+    playerState.preloadPlayer = undefined;
+
+    for (const sessionId of created) {
+      streamingSessionStore.deleteSession(sessionId);
+    }
+
+    created.length = 0;
+  });
+
+  it("does not leak an 'ended' event and transitions to the preloaded product on a gapless boundary", async () => {
+    const current = 'gapless-current';
+    const next = 'gapless-next';
+    created.push(current, next);
+    seedStartedProduct(current);
+    seedPreloadedProduct(next);
+
+    const { native, player } = createNativePlayer();
+    player.currentStreamingSessionId = current;
+    player.preloadedStreamingSessionId = next;
+    player.currentTime = 20;
+    playerState.activePlayer = player;
+    playerState.preloadPlayer = player;
+
+    const endedEvents: Array<EndedEvent> = [];
+    const transitions: Array<MediaProductTransition> = [];
+    const onEnded = (e: Event) => endedEvents.push(e as EndedEvent);
+    const onTransition = (e: Event) =>
+      transitions.push(e as MediaProductTransition);
+    events.addEventListener('ended', onEnded);
+    events.addEventListener('media-product-transition', onTransition);
+
+    // Native pipeline reports the outgoing track finished; playback has
+    // already continued into the preloaded track.
+    native.emit('mediastate', 'completed');
+    // handleAutomaticTransitionToPreloadedMediaProduct awaits these.
+    native.emit('mediaduration', 20);
+    await flush();
+    native.emit('mediastate', 'active');
+    await flush();
+
+    events.removeEventListener('ended', onEnded);
+    events.removeEventListener('media-product-transition', onTransition);
+
+    expect(endedEvents.length).to.equal(0);
+    expect(player.currentStreamingSessionId).to.equal(next);
+    expect(
+      transitions.some(e => e.detail.mediaProduct.productId === next),
+    ).to.equal(true);
+  });
+
+  it("emits an 'ended' event on the final track boundary when nothing is preloaded", () => {
+    const current = 'final-current';
+    created.push(current);
+    seedStartedProduct(current);
+
+    const { native, player } = createNativePlayer();
+    player.currentStreamingSessionId = current;
+    player.currentTime = 20;
+
+    const endedEvents: Array<EndedEvent> = [];
+    const onEnded = (e: Event) => endedEvents.push(e as EndedEvent);
+    events.addEventListener('ended', onEnded);
+
+    native.emit('mediastate', 'completed');
+
+    events.removeEventListener('ended', onEnded);
+
+    expect(endedEvents.length).to.equal(1);
+    expect(endedEvents[0]?.detail.reason).to.equal('completed');
+  });
+});
+
+describe('BasePlayer.mediaProductStarted preload bookkeeping', () => {
+  const created: Array<string> = [];
+
+  afterEach(() => {
+    for (const sessionId of created) {
+      streamingSessionStore.deleteSession(sessionId);
+    }
+
+    created.length = 0;
+  });
+
+  it('clears the preload when the started session is the one that was preloaded', () => {
+    const started = 'started-match';
+    created.push(started);
+
+    const player = new BasePlayer();
+    player.preloadedStreamingSessionId = started;
+
+    player.mediaProductStarted(started);
+
+    expect(player.preloadedStreamingSessionId).to.equal(undefined);
+  });
+
+  it('keeps a replacement preload registered mid-transition (setNext race)', () => {
+    const started = 'started-race';
+    const replacement = 'replacement-preload';
+    created.push(started, replacement);
+
+    const player = new BasePlayer();
+    // A setNext() landing during the transition replaced the preload with a
+    // different session than the one that just started.
+    player.preloadedStreamingSessionId = replacement;
+
+    player.mediaProductStarted(started);
+
+    expect(player.preloadedStreamingSessionId).to.equal(replacement);
+  });
+});

--- a/packages/player/src/player/nativePlayer.ts
+++ b/packages/player/src/player/nativePlayer.ts
@@ -229,13 +229,26 @@ export default class NativePlayer extends BasePlayer {
    * can gather the duration data and send a media product transition.
    */
   async handleAutomaticTransitionToPreloadedMediaProduct() {
-    await this.nativeEvent('mediaduration');
+    // Capture which preloaded item the native pipeline committed to at the
+    // track boundary; a concurrent setNext() can replace
+    // this.preloadedStreamingSessionId while we await the duration and
+    // active signals below, which would attribute the audible stream to the
+    // wrong media product.
+    const committedStreamingSessionId = this.preloadedStreamingSessionId;
+
+    // Read the duration off the awaited event; the #duration field is
+    // updated by a separate listener that is not guaranteed to have run
+    // before this waiter settles.
+    const mediaDurationEvent = (await this.nativeEvent(
+      'mediaduration',
+    )) as Event & { target: number };
+    this.#duration = Number(mediaDurationEvent.target);
 
     this.#preloadedLoadPayload = undefined;
 
     const mediaProductTransition =
       streamingSessionStore.getMediaProductTransition(
-        this.preloadedStreamingSessionId,
+        committedStreamingSessionId,
       );
 
     if (!mediaProductTransition) {
@@ -254,9 +267,9 @@ export default class NativePlayer extends BasePlayer {
       actualDuration: this.#duration,
     };
 
-    if (this.preloadedStreamingSessionId) {
+    if (committedStreamingSessionId) {
       streamingSessionStore.saveMediaProductTransition(
-        this.preloadedStreamingSessionId,
+        committedStreamingSessionId,
         {
           mediaProduct,
           playbackContext: updatedPlaybackContext,
@@ -270,7 +283,7 @@ export default class NativePlayer extends BasePlayer {
       mediaProductTransitionEvent(mediaProduct, updatedPlaybackContext),
     );
 
-    this.currentStreamingSessionId = this.preloadedStreamingSessionId;
+    this.currentStreamingSessionId = committedStreamingSessionId;
 
     this.mediaProductStarted(this.currentStreamingSessionId);
   }
@@ -300,7 +313,13 @@ export default class NativePlayer extends BasePlayer {
       throw new Error('Stream format is undefined.');
     }
 
-    await mediaDurationEventPromise;
+    // Read the duration off the awaited event; the #duration field is
+    // updated by a separate listener that is not guaranteed to have run
+    // before this waiter settles.
+    const mediaDurationEvent = (await mediaDurationEventPromise) as Event & {
+      target: number;
+    };
+    this.#duration = Number(mediaDurationEvent.target);
 
     // Player was reset during load, do not continue.
     if (this.currentStreamingSessionId !== streamInfo.streamingSessionId) {
@@ -479,7 +498,31 @@ export default class NativePlayer extends BasePlayer {
       'mediastate',
       (e: Event & { target: string }) => {
         if (e.target === 'completed') {
-          this.finishCurrentMediaProduct('completed');
+          // A preloaded next item means the native pipeline transitions
+          // gaplessly on its own. Finalize seamlessly so no 'ended' event
+          // reaches the app mid-transition, and drive the transition
+          // directly since the suppressed 'ended' event no longer invokes
+          // playbackEngineEndedHandler.
+          const isSeamlessTransition = Boolean(this.hasNextItem());
+
+          if (isSeamlessTransition) {
+            timestamps.mark(
+              'streaming_metrics:playback_statistics:idealStartTimestamp',
+              playerState.preloadedStreamingSessionId,
+            );
+          }
+
+          this.finishCurrentMediaProduct('completed', isSeamlessTransition);
+
+          if (isSeamlessTransition) {
+            this.updateVolumeLevelForNextProduct();
+
+            if (this.isActivePlayer) {
+              this.handleAutomaticTransitionToPreloadedMediaProduct().catch(
+                console.error,
+              );
+            }
+          }
         } else {
           this.#handleNativePlayerStateChange(e.target);
         }


### PR DESCRIPTION
## Problem

On desktop (NativePlayer), every gapless track boundary dispatched a public `ended` event: the `mediastate: 'completed'` handler called `finishCurrentMediaProduct('completed')` without `isSeamlessTransition`, while ShakaPlayer passes `true` on the equivalent path. Playback had already continued gaplessly into the preloaded next track, so apps reacting to `ended` (the webclient force-loads the next queue item when a preload is still in flight) race the SDK's own automatic transition.

With a `setNext()` playbackinfo fetch in flight at the boundary — exactly what happens when a user hits **Play Next** in the last seconds of a track — the result is a double transition: the app hard-loads one track (`media.stop` + `media.load`, cutting the audible stream) while the SDK transitions to another, the play queue consumes the wrong element, `currentIndex` lands on `-1`, and the UI desyncs from the audio (tracked as TDAPEX-2123; ~17 customer tickets in 2026, desktop-concentrated).

## Fix

- **`nativePlayer` completed-handler**: finalize the boundary with `isSeamlessTransition = Boolean(hasNextItem())` so no `ended` leaks mid-transition, and drive `handleAutomaticTransitionToPreloadedMediaProduct()` directly (the suppressed `ended` no longer invokes `playbackEngineEndedHandler`).
- **`handleAutomaticTransitionToPreloadedMediaProduct`**: capture the committed preload session id at entry; a concurrent `setNext()` can replace `preloadedStreamingSessionId` during the `mediaduration`/`active` awaits, which attributed the audible stream to the wrong media product.
- **`basePlayer.mediaProductStarted`**: only clear preload bookkeeping when it still refers to the session that just started, so a replacement preload registered mid-transition stays tracked and gets cancelled (`media.cancelpreload`) at the next preload window instead of playing unannounced.
- **`load()` / transition handler**: read the duration off the awaited `mediaduration` event instead of the `#duration` field, so the value does not depend on listener registration order across the Electron contextBridge.

## Verification

Reproduced and verified against the real desktop app + native player with a deterministic harness: playback of an album queue, a **Play Next** dispatched 5s before a gapless boundary with its playbackinfo response held until the native `completed` signal. Verification was re-run on this exact branch state (rebased onto main).

- **Before** (stock 0.18.3): leaked `ended` → app force-load races SDK transition → `media.stop`+`media.load` hard cut ~75ms into the next track, Play Next element consumed unplayed, `currentIndex=-1`, album restarts from track 1.
- **After**: single correctly-attributed transition to the natively committed track (native duration, correct product id), no `ended` leak, no stop/load cut, queue index consistent; the late-resolving `setNext` preload is registered ~50ms after the boundary with no playback disruption and gets replaced (`media.cancelpreload` + fresh preload) at the next −15s preload window; subsequent boundaries all clean.

## Notes for review

- Package tests: 110 passed / 0 failed locally; the handful of suites requiring `TEST_USER` credentials fail to import locally with or without this change.
- Residual behavior (pre-existing, all platforms): a Play Next whose playbackinfo resolves after the boundary has its queue element consumed without playing — UI stays consistent with audio; making it survive the boundary would be an app-side queue change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)