### PR TITLE
fix(api): preserve UTF-8 when buffering responses

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.1] - 2026-08-03
+
+### Fixed
+
+- Decode response bodies through the runtime's `Response` implementation before
+  buffering them, preventing UTF-8 text corruption in React Native clients.
+
 ## [0.39.0] - 2026-07-30
 
 ### Changed

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/api",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "type": "module",
   "files": [
     "dist"

--- a/packages/api/src/retry.test.ts
+++ b/packages/api/src/retry.test.ts
@@ -40,6 +40,46 @@ describe('fetchWithRetry', () => {
     expect(base).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves UTF-8 when the runtime decodes ArrayBuffer bodies bytewise', async () => {
+    const payload = JSON.stringify({ title: 'Populära album · För dig' });
+    const source = new Response(new TextEncoder().encode(payload), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
+    });
+    class BytewiseResponse extends Response {
+      readonly #bodyIsText: boolean;
+
+      constructor(body?: BodyInit | null, init?: ResponseInit) {
+        super(body, init);
+        this.#bodyIsText = typeof body === 'string';
+      }
+
+      override async text(): Promise<string> {
+        if (this.#bodyIsText) {
+          return super.text();
+        }
+        const bytes = new Uint8Array(await this.arrayBuffer());
+        return Array.from(bytes, byte => String.fromCharCode(byte)).join('');
+      }
+    }
+    vi.stubGlobal('Response', BytewiseResponse);
+
+    try {
+      const base = vi
+        .fn<(input: Request) => Promise<Response>>()
+        .mockResolvedValue(source);
+      const fetcher = fetchWithRetry(defaultRetryOptions, base);
+
+      const response = await fetcher(get());
+
+      expect(JSON.parse(await response.text())).toEqual({
+        title: 'Populära album · För dig',
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('retries a 503 then succeeds', async () => {
     const base = vi
       .fn<(input: Request) => Promise<Response>>()
@@ -79,8 +119,6 @@ describe('fetchWithRetry', () => {
   });
 
   it('gives up after maxRetries and returns the final error response', async () => {
-    // mockImplementation (not mockResolvedValue) so each attempt gets a fresh
-    // Response — the retry layer drains the body of each one.
     const base = vi
       .fn<(input: Request) => Promise<Response>>()
       .mockImplementation(() => Promise.resolve(status(503)));

--- a/packages/api/src/retry.ts
+++ b/packages/api/src/retry.ts
@@ -219,15 +219,14 @@ async function runAttempt(
 }
 
 /**
- * Read the response body fully into memory and return an equivalent response
- * backed by those bytes. The rebuilt response drops `Response.url`/`redirected`,
- * which this client does not rely on.
+ * Read the response body fully through its platform implementation, then
+ * return an equivalent response backed by the decoded text.
  */
 async function bufferBody(response: Response): Promise<Response> {
   if (!response.body) {
     return response;
   }
-  const body = await response.arrayBuffer();
+  const body = await response.text();
   return new Response(body, {
     headers: response.headers,
     status: response.status,


### PR DESCRIPTION
## Summary

- Buffer retryable API responses through the originating runtime’s `Response.text()` implementation before rebuilding them.
- Prevent React Native clients from decoding UTF-8 `ArrayBuffer` bytes as individual code points.
- Release the fix as `@tidal-music/api` 0.39.1.

## Root cause

The retry/read-timeout layer introduced in 0.29.0 consumed each response as an `ArrayBuffer` and rebuilt it with the global `Response` constructor. Expo’s fetch response decodes UTF-8 correctly, but React Native’s global response polyfill handles an `ArrayBuffer`-backed `.text()` byte-by-byte. A Swedish title such as `Populära album` therefore became `PopulÃ¤ra album`.

The API surface is textual JSON:API, so buffering through the source response’s `.text()` keeps the body inside the read-timeout window while applying the runtime’s correct UTF-8 decoder. Rebuilding from the decoded string also works with React Native, where `Response.clone()` is not implemented by Expo fetch.

## Validation

- `pnpm --filter @tidal-music/api test --run` — 29 passed
- `pnpm --filter @tidal-music/api lint:ci`
- `pnpm --filter @tidal-music/api typecheck`
- `pnpm --filter @tidal-music/api build`
- `pnpm --filter @tidal-music/api check:types-resolution`
- `pnpm lint:ci && pnpm typecheck`
- `./bin/check-version-bump.sh packages/api/package.json`

Supersedes the app-local workaround in tidal-engineering/tidal-app#313.