### PR TITLE
Only report playback start timestamps when playback actually started; fix playback_info_fetch error reporting

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `playback_statistics` now reports `actualStartTimestamp` and
+  `idealStartTimestamp` as `null` instead of `0` when playback never actually
+  started (e.g. the session errored out before the first frame/sample).
+  Never-started sessions previously reported both timestamps as `0`, which
+  skewed startup time metrics towards zero whenever error rates rose.
+
+### Fixed
+
+- `playback_info_fetch` events now correctly report `endReason: 'ERROR'` and
+  the error code/message when fetching playback info fails. The error fields
+  were previously written in a separate reducer call that raced with the
+  final one, so the committed event always ended up with the default
+  `endReason: 'COMPLETE'` and errors were never reported. The error code now
+  also uses the structured `PlayerError` code (e.g. `NPBI0`, `A4033`) when
+  available instead of the free-form error message.
+
 ## [0.18.3] - 2026-06-23
 
 ### Fixed

--- a/packages/player/src/internal/event-tracking/streaming-metrics/playback-statistics.test.ts
+++ b/packages/player/src/internal/event-tracking/streaming-metrics/playback-statistics.test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+
+import { playbackStatistics } from './playback-statistics.js';
+
+describe('playbackStatistics', () => {
+  it('keeps start timestamps null when playback never started', async () => {
+    const event = await playbackStatistics({
+      streamingSessionId: crypto.randomUUID(),
+    });
+
+    // Never-started sessions must report null (not 0) so they can be
+    // excluded from startup time metrics.
+    expect(event?.payload.actualStartTimestamp).to.equal(null);
+    expect(event?.payload.idealStartTimestamp).to.equal(null);
+  });
+
+  it('keeps reported start timestamps across subsequent updates', async () => {
+    const streamingSessionId = crypto.randomUUID();
+
+    await playbackStatistics({
+      actualStartTimestamp: 1234,
+      streamingSessionId,
+    });
+    const event = await playbackStatistics({
+      idealStartTimestamp: 1000,
+      streamingSessionId,
+    });
+
+    expect(event?.payload.actualStartTimestamp).to.equal(1234);
+    expect(event?.payload.idealStartTimestamp).to.equal(1000);
+  });
+});

--- a/packages/player/src/internal/event-tracking/streaming-metrics/playback-statistics.ts
+++ b/packages/player/src/internal/event-tracking/streaming-metrics/playback-statistics.ts
@@ -31,7 +31,12 @@ export type BasePayload = {
   actualAssetPresentation: 'FULL' | 'PREVIEW';
   actualAudioMode: 'DOLBY_ATMOS' | 'SONY_360RA' | 'STEREO';
   actualProductId: string | null;
-  actualStartTimestamp: number;
+  /**
+   * Null when playback never actually started (e.g. the session ended in an
+   * error before the first frame/sample was played). Consumers use this to
+   * exclude never-started sessions from startup time metrics.
+   */
+  actualStartTimestamp: number | null;
   actualStreamType: 'LIVE' | 'ON_DEMAND';
   adaptations: Array<Adaptation>;
   cdm: 'FAIR_PLAY' | 'NONE' | 'WIDEVINE';
@@ -41,7 +46,10 @@ export type BasePayload = {
   errorCode: string | null;
   errorMessage: string | null;
   hasAds: boolean;
-  idealStartTimestamp: number;
+  /**
+   * Null when playback never actually started, see actualStartTimestamp.
+   */
+  idealStartTimestamp: number | null;
   outputDevice: StatisticsOutputType | null;
   productType: 'TRACK' | 'VIDEO';
   stalls: Array<Stall>;
@@ -94,7 +102,7 @@ const defaultPayload: Payload = {
   actualAudioMode: 'STEREO',
   actualProductId: null,
   actualQuality: 'LOSSLESS',
-  actualStartTimestamp: 0,
+  actualStartTimestamp: null,
   actualStreamType: 'ON_DEMAND',
   adaptations: [],
   cdm: 'WIDEVINE',
@@ -104,7 +112,7 @@ const defaultPayload: Payload = {
   errorCode: null,
   errorMessage: null,
   hasAds: false,
-  idealStartTimestamp: 0,
+  idealStartTimestamp: null,
   outputDevice: null,
   productType: 'TRACK',
   stalls: [],

--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -1,6 +1,11 @@
 import { expect } from 'chai';
 
-import { authAndEvents, credentialsProvider } from '../../test-helpers.js';
+import {
+  authAndEvents,
+  credentialsProvider,
+  waitFor,
+} from '../../test-helpers.js';
+import { eventSenderStore } from '../index.js';
 
 import { fetchPlaybackInfo } from './playback-info-resolver.js';
 
@@ -218,5 +223,78 @@ describe('playbackInfoResolver', () => {
       representationCount,
       'Non-ABR manifest should contain exactly one quality representation',
     ).to.equal(1);
+  });
+
+  it('commits playback_info_fetch with endReason ERROR when the fetch fails', async () => {
+    const { clientId, token } = await credentialsProvider.getCredentials();
+
+    if (!token) {
+      throw new Error('No access token, cannot fulfill test.');
+    }
+
+    type SentEvent = {
+      name: string;
+      payload: { endReason?: string; errorCode?: string | null };
+    };
+    const sentEvents: Array<SentEvent> = [];
+    const originalEventSender = eventSenderStore.eventSender;
+
+    eventSenderStore.eventSender = {
+      ...originalEventSender,
+      sendEvent(event: Parameters<typeof originalEventSender.sendEvent>[0]) {
+        sentEvents.push(event as SentEvent);
+      },
+    };
+
+    try {
+      let thrownError: unknown;
+
+      try {
+        await fetchPlaybackInfo({
+          accessToken: token,
+          audioAdaptiveBitrateStreaming: true,
+          audioQuality: 'LOSSLESS',
+          clientId,
+          mediaProduct: {
+            // Nonexistent track id, the manifest fetch responds with an error
+            productId: '0',
+            productType: 'track',
+            sourceId: '',
+            sourceType: '',
+          },
+          playerType: 'shaka',
+          prefetch: false,
+          // eslint-disable-next-line no-restricted-syntax
+          streamingSessionId: `tidal-player-js-test-${Date.now()}`,
+        });
+      } catch (e) {
+        thrownError = e;
+      }
+
+      expect(thrownError, 'fetchPlaybackInfo should throw').to.not.equal(
+        undefined,
+      );
+
+      // The event is committed in a fire-and-forget fashion, poll for it.
+      let playbackInfoFetchEvent: SentEvent | undefined;
+      for (let i = 0; i < 40 && !playbackInfoFetchEvent; i++) {
+        playbackInfoFetchEvent = sentEvents.find(
+          event => event.name === 'playback_info_fetch',
+        );
+        if (!playbackInfoFetchEvent) {
+          await waitFor(50);
+        }
+      }
+
+      if (!playbackInfoFetchEvent) {
+        throw new Error('No playback_info_fetch event was sent.');
+      }
+
+      expect(playbackInfoFetchEvent.payload.endReason).to.equal('ERROR');
+      expect(playbackInfoFetchEvent.payload.errorCode).to.not.equal(null);
+      expect(playbackInfoFetchEvent.payload.errorCode).to.not.equal(undefined);
+    } finally {
+      eventSenderStore.eventSender = originalEventSender;
+    }
   });
 });

--- a/packages/player/src/internal/helpers/playback-info-resolver.test.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.test.ts
@@ -234,7 +234,11 @@ describe('playbackInfoResolver', () => {
 
     type SentEvent = {
       name: string;
-      payload: { endReason?: string; errorCode?: string | null };
+      payload: {
+        endReason?: string;
+        errorCode?: string | null;
+        streamingSessionId?: string;
+      };
     };
     const sentEvents: Array<SentEvent> = [];
     const originalEventSender = eventSenderStore.eventSender;
@@ -248,6 +252,9 @@ describe('playbackInfoResolver', () => {
 
     try {
       let thrownError: unknown;
+
+      // eslint-disable-next-line no-restricted-syntax
+      const streamingSessionId = `tidal-player-js-test-${Date.now()}`;
 
       try {
         await fetchPlaybackInfo({
@@ -264,8 +271,7 @@ describe('playbackInfoResolver', () => {
           },
           playerType: 'shaka',
           prefetch: false,
-          // eslint-disable-next-line no-restricted-syntax
-          streamingSessionId: `tidal-player-js-test-${Date.now()}`,
+          streamingSessionId,
         });
       } catch (e) {
         thrownError = e;
@@ -276,10 +282,15 @@ describe('playbackInfoResolver', () => {
       );
 
       // The event is committed in a fire-and-forget fashion, poll for it.
+      // Scope the lookup to this test's session; telemetry from earlier
+      // tests is also fire-and-forget and can arrive after our sender stub
+      // is installed.
       let playbackInfoFetchEvent: SentEvent | undefined;
       for (let i = 0; i < 40 && !playbackInfoFetchEvent; i++) {
         playbackInfoFetchEvent = sentEvents.find(
-          event => event.name === 'playback_info_fetch',
+          event =>
+            event.name === 'playback_info_fetch' &&
+            event.payload.streamingSessionId === streamingSessionId,
         );
         if (!playbackInfoFetchEvent) {
           await waitFor(50);
@@ -290,9 +301,19 @@ describe('playbackInfoResolver', () => {
         throw new Error('No playback_info_fetch event was sent.');
       }
 
+      // The reported errorCode should be the structured PlayerError code
+      // (falling back to the error message for plain errors), not just any
+      // non-empty value.
+      const expectedErrorCode =
+        (thrownError as { errorCode?: string }).errorCode ??
+        (thrownError as Error).message;
+
       expect(playbackInfoFetchEvent.payload.endReason).to.equal('ERROR');
-      expect(playbackInfoFetchEvent.payload.errorCode).to.not.equal(null);
-      expect(playbackInfoFetchEvent.payload.errorCode).to.not.equal(undefined);
+      expect(playbackInfoFetchEvent.payload.errorCode).to.equal(
+        expectedErrorCode,
+      );
+      expect(playbackInfoFetchEvent.payload.errorCode).to.be.a('string');
+      expect(playbackInfoFetchEvent.payload.errorCode).to.have.length.above(0);
     } finally {
       eventSenderStore.eventSender = originalEventSender;
     }

--- a/packages/player/src/internal/helpers/playback-info-resolver.ts
+++ b/packages/player/src/internal/helpers/playback-info-resolver.ts
@@ -500,6 +500,7 @@ async function _fetchVideoManifest(options: Options): Promise<PlaybackInfo> {
 export async function fetchPlaybackInfo(options: Options) {
   const { streamingSessionId } = options;
   const events = [];
+  let fetchError: Error | PlayerError | undefined;
 
   timestamps.mark(
     'streaming_metrics:playback_info_fetch:startTimestamp',
@@ -520,11 +521,6 @@ export async function fetchPlaybackInfo(options: Options) {
     if (playbackInfo === undefined) {
       throw new Error('Playback info was fetched, but undefined.');
     }
-
-    StreamingMetrics.playbackInfoFetch({
-      endReason: 'COMPLETE',
-      streamingSessionId,
-    }).catch(console.error);
 
     const hasAds = 'adInfo' in playbackInfo;
 
@@ -560,17 +556,12 @@ export async function fetchPlaybackInfo(options: Options) {
 
     return playbackInfo;
   } catch (e) {
+    fetchError = e as Error | PlayerError;
+
     timestamps.mark(
       'streaming_metrics:playback_info_fetch:endTimestamp',
       streamingSessionId,
     );
-
-    StreamingMetrics.playbackInfoFetch({
-      endReason: 'ERROR',
-      errorCode: (e as Error | PlayerError).message,
-      errorMessage: (e as Error | PlayerError).stack,
-      streamingSessionId,
-    }).catch(console.error);
 
     events.push(
       StreamingMetrics.streamingSessionEnd({
@@ -585,12 +576,25 @@ export async function fetchPlaybackInfo(options: Options) {
     // Continue throwing to the loadHandler and nextHandler.
     throw e;
   } finally {
+    /*
+      The error fields must be part of this single reducer call. Previously
+      they were written in a separate fire-and-forget call from the catch
+      block, which raced with this one: both calls read the stored event
+      before either had written, so the payload committed below always came
+      out with the default endReason 'COMPLETE' and errors were never
+      reported.
+    */
     events.push(
       StreamingMetrics.playbackInfoFetch({
+        endReason: fetchError ? 'ERROR' : 'COMPLETE',
         endTimestamp: timestamps.get(
           'streaming_metrics:playback_info_fetch:endTimestamp',
           streamingSessionId,
         ),
+        errorCode: fetchError
+          ? ((fetchError as PlayerError).errorCode ?? fetchError.message)
+          : null,
+        errorMessage: fetchError ? (fetchError.stack ?? null) : null,
         startTimestamp: timestamps.get(
           'streaming_metrics:playback_info_fetch:startTimestamp',
           streamingSessionId,

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -434,14 +434,16 @@ export class BasePlayer {
 
     // Start filling in playbackStatistics
     StreamingMetrics.playbackStatistics({
-      actualStartTimestamp: timestamps.get(
-        'streaming_metrics:playback_statistics:actualStartTimestamp',
-        streamingSessionId,
-      ),
-      idealStartTimestamp: timestamps.get(
-        'streaming_metrics:playback_statistics:idealStartTimestamp',
-        streamingSessionId,
-      ),
+      actualStartTimestamp:
+        timestamps.get(
+          'streaming_metrics:playback_statistics:actualStartTimestamp',
+          streamingSessionId,
+        ) ?? null,
+      idealStartTimestamp:
+        timestamps.get(
+          'streaming_metrics:playback_statistics:idealStartTimestamp',
+          streamingSessionId,
+        ) ?? null,
       outputDevice: this.#outputDeviceType,
       streamingSessionId,
     }).catch(console.error);


### PR DESCRIPTION
## Why

When web streaming error rates rise, the "startup time" dashboards improve — because sessions that error out before playback starts still emit `playback_statistics` with the default `actualStartTimestamp: 0` and `idealStartTimestamp: 0`, contributing bogus zero startup times. Separately, `playback_info_fetch` never reported errors: the error fields were written in a fire-and-forget reducer call that raced with the final call in the `finally` block, so the committed event always carried the default `endReason: 'COMPLETE'`.

## What

- `playback_statistics`: `actualStartTimestamp` / `idealStartTimestamp` are now `number | null`, defaulting to `null`. They are only populated when playback actually starts; never-started sessions report `null` (with `endReason` still `ERROR`) so consumers can exclude them from startup time metrics.
- `playback_info_fetch`: error fields are set in the single reducer call in the `finally` block, eliminating the race. The structured `PlayerError` code (e.g. `NPBI0`, `A4033`) is reported as `errorCode` when available, instead of the free-form message.

## Verified

Typecheck and lint pass. Added an integration test asserting `playback_info_fetch` is committed with `endReason: 'ERROR'` and a non-null `errorCode` when the manifest fetch fails (runs in CI with the test user).

Made with [Cursor](https://cursor.com)