### PR TITLE
Strict actualStartTimestamp semantics + serialized event reducers

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -20,8 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Sessions that request playback but never produce audio (e.g. stuck
   buffering, error mid-startup) now report `actualStartTimestamp: null`
   instead of the `play()` invocation time, and startup time now includes the
-  initial buffering period. Seamless transitions (gapless/crossfade) are
-  still stamped at the transition swap, as before.
+  initial buffering period.
+- Crossfade/gapless transitions now stamp the incoming track at fade start
+  instead of fade end: `idealStartTimestamp` is set when the transition is
+  triggered and `actualStartTimestamp` when the incoming element starts
+  playing. The outgoing track still reports until it stops at fade end, so
+  the two sessions intentionally overlap in wall-clock time.
 
 ### Fixed
 

--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   started (e.g. the session errored out before the first frame/sample).
   Never-started sessions previously reported both timestamps as `0`, which
   skewed startup time metrics towards zero whenever error rates rose.
+- Strict `actualStartTimestamp` semantics: the timestamp is now captured when
+  the media element actually starts producing output (first `playing` event,
+  or the native player's `active` state) instead of when `play()` is invoked.
+  Sessions that request playback but never produce audio (e.g. stuck
+  buffering, error mid-startup) now report `actualStartTimestamp: null`
+  instead of the `play()` invocation time, and startup time now includes the
+  initial buffering period. Seamless transitions (gapless/crossfade) are
+  still stamped at the transition swap, as before.
 
 ### Fixed
 
@@ -24,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `endReason: 'COMPLETE'` and errors were never reported. The error code now
   also uses the structured `PlayerError` code (e.g. `NPBI0`, `A4033`) when
   available instead of the free-form error message.
+- Event reducers now serialize their read-merge-write cycles. Two updates to
+  the same event racing in the same tick could previously drop one update's
+  fields (the same class of bug as the `playback_info_fetch` error reporting
+  fix above).
 
 ## [0.18.4] - 2026-07-27
 

--- a/packages/player/src/internal/helpers/reducer.test.ts
+++ b/packages/player/src/internal/helpers/reducer.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+
+import { createReducer } from './reducer.js';
+
+describe('createReducer', () => {
+  it('merges fields from consecutive calls for the same session', async () => {
+    const reducer = await createReducer('test_reducer_merge', {
+      fieldA: null as number | null,
+      fieldB: null as number | null,
+    });
+
+    const streamingSessionId = crypto.randomUUID();
+
+    await reducer({ fieldA: 1, streamingSessionId });
+    const result = await reducer({ fieldB: 2, streamingSessionId });
+
+    expect(result?.payload.fieldA).to.equal(1);
+    expect(result?.payload.fieldB).to.equal(2);
+  });
+
+  it('does not drop fields when calls for the same session race', async () => {
+    const reducer = await createReducer('test_reducer_race', {
+      fieldA: null as number | null,
+      fieldB: null as number | null,
+    });
+
+    const streamingSessionId = crypto.randomUUID();
+
+    // Both calls start in the same tick. Without serialized invocations both
+    // would read the stored state before either has written, and the last
+    // write would silently drop the other call's field.
+    const [, second] = await Promise.all([
+      reducer({ fieldA: 1, streamingSessionId }),
+      reducer({ fieldB: 2, streamingSessionId }),
+    ]);
+
+    expect(second?.payload.fieldA).to.equal(1);
+    expect(second?.payload.fieldB).to.equal(2);
+  });
+});

--- a/packages/player/src/internal/helpers/reducer.ts
+++ b/packages/player/src/internal/helpers/reducer.ts
@@ -13,7 +13,9 @@ export async function createReducer<P, N extends string>(
       Promise.resolve(undefined);
   }
 
-  return async (newData: Partial<P> & { streamingSessionId: string }) => {
+  const reduce = async (
+    newData: Partial<P> & { streamingSessionId: string },
+  ) => {
     try {
       const savedEvent = await db.get<P>({
         name,
@@ -53,5 +55,21 @@ export async function createReducer<P, N extends string>(
     } catch (e) {
       console.error(e);
     }
+  };
+
+  /*
+    Serialize invocations. Each call does an async read-merge-write against
+    the same stored event, so two calls in flight at the same time would both
+    read the stored state before either has written, and the last write would
+    silently drop the other call's fields. Chaining every invocation on the
+    previous one guarantees the merge sees all earlier writes.
+  */
+  let lastInvocation: Promise<unknown> = Promise.resolve();
+
+  return (newData: Partial<P> & { streamingSessionId: string }) => {
+    // reduce() never rejects (errors are caught and logged inside).
+    const invocation = lastInvocation.then(() => reduce(newData));
+    lastInvocation = invocation;
+    return invocation;
   };
 }

--- a/packages/player/src/internal/helpers/streaming-session-store.ts
+++ b/packages/player/src/internal/helpers/streaming-session-store.ts
@@ -8,6 +8,10 @@ class StreamingSessionStore {
 
   #playbackInfos = new Map<string, PlaybackInfo>();
 
+  // Sessions that have had their actual playback start reported, see
+  // BasePlayer.mediaProductActuallyStarted.
+  #reportedActualStarts = new Set<string>();
+
   #startedStreamInfos = new Map<string, boolean>();
 
   #streamInfos = new Map<string, StreamInfo>();
@@ -59,6 +63,7 @@ class StreamingSessionStore {
   deleteSession(streamingSessionId: string) {
     this.deleteMediaProductTransition(streamingSessionId);
     this.#playbackInfos.delete(streamingSessionId);
+    this.#reportedActualStarts.delete(streamingSessionId);
     this.#startedStreamInfos.delete(streamingSessionId);
     this.deleteStreamInfo(streamingSessionId);
   }
@@ -103,6 +108,10 @@ class StreamingSessionStore {
     return this.#playbackInfos.has(streamingSessionId);
   }
 
+  hasReportedActualStart(streamingSessionId: string) {
+    return this.#reportedActualStarts.has(streamingSessionId);
+  }
+
   hasStartedStreamInfo(streamingSessionId: string) {
     return this.#startedStreamInfos.has(streamingSessionId);
   }
@@ -143,6 +152,10 @@ class StreamingSessionStore {
 
   saveStreamInfo(streamingSessionId: string, streamInfo: StreamInfo) {
     this.#streamInfos.set(streamingSessionId, streamInfo);
+  }
+
+  setReportedActualStart(streamingSessionId: string) {
+    this.#reportedActualStarts.add(streamingSessionId);
   }
 
   setStartedStreamInfo(streamingSessionId: string) {

--- a/packages/player/src/player/basePlayer.test.ts
+++ b/packages/player/src/player/basePlayer.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+
+import { db } from '../internal/helpers/event-session.js';
+import { streamingSessionStore } from '../internal/helpers/streaming-session-store.js';
+import { waitFor } from '../internal/helpers/wait-for.js';
+
+import { BasePlayer } from './basePlayer.js';
+
+type PlaybackStatisticsPayload = { actualStartTimestamp: number | null };
+
+async function getPlaybackStatistics(streamingSessionId: string) {
+  // The reducer write is fire-and-forget, poll for it.
+  for (let i = 0; i < 40; i++) {
+    const event = await db.get<PlaybackStatisticsPayload>({
+      name: 'playback_statistics',
+      streamingSessionId,
+    });
+
+    if (event) {
+      return event;
+    }
+
+    await waitFor(10);
+  }
+
+  return undefined;
+}
+
+describe('BasePlayer.mediaProductActuallyStarted', () => {
+  it('reports actualStartTimestamp only for the first call per session', async () => {
+    const player = new BasePlayer();
+    const streamingSessionId = crypto.randomUUID();
+
+    player.mediaProductActuallyStarted(streamingSessionId);
+
+    const event = await getPlaybackStatistics(streamingSessionId);
+    const firstValue = event?.payload.actualStartTimestamp;
+
+    expect(firstValue).to.be.a('number');
+
+    // A later call (e.g. 'playing' after resume from pause or stall) must
+    // not overwrite the reported value. Wait so a re-report would yield a
+    // different timestamp, then give the (fire-and-forget) write time to
+    // land before re-reading.
+    await waitFor(20);
+    player.mediaProductActuallyStarted(streamingSessionId);
+    await waitFor(20);
+
+    const eventAfterSecondCall =
+      await getPlaybackStatistics(streamingSessionId);
+
+    expect(eventAfterSecondCall?.payload.actualStartTimestamp).to.equal(
+      firstValue,
+    );
+
+    streamingSessionStore.deleteSession(streamingSessionId);
+  });
+
+  it('does nothing for an undefined streaming session id', () => {
+    const player = new BasePlayer();
+
+    expect(() => player.mediaProductActuallyStarted(undefined)).to.not.throw();
+  });
+});

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -431,9 +431,9 @@ export class BasePlayer {
       Start filling in playbackStatistics. actualStartTimestamp is deliberately
       not reported here: this method runs when playback is requested (play()),
       not when audio actually starts. mediaProductActuallyStarted() reports it
-      from the media element's 'playing' signal (or the seamless transition
-      swap), so sessions that never produce audio keep actualStartTimestamp
-      as null.
+      from the media element's 'playing' signal -- or, for crossfade/gapless
+      transitions, at fade start when the incoming element begins playing --
+      so sessions that never produce audio keep actualStartTimestamp as null.
     */
     StreamingMetrics.playbackStatistics({
       idealStartTimestamp:

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -427,18 +427,15 @@ export class BasePlayer {
       return;
     }
 
-    timestamps.mark(
-      'streaming_metrics:playback_statistics:actualStartTimestamp',
-      streamingSessionId,
-    );
-
-    // Start filling in playbackStatistics
+    /*
+      Start filling in playbackStatistics. actualStartTimestamp is deliberately
+      not reported here: this method runs when playback is requested (play()),
+      not when audio actually starts. mediaProductActuallyStarted() reports it
+      from the media element's 'playing' signal (or the seamless transition
+      swap), so sessions that never produce audio keep actualStartTimestamp
+      as null.
+    */
     StreamingMetrics.playbackStatistics({
-      actualStartTimestamp:
-        timestamps.get(
-          'streaming_metrics:playback_statistics:actualStartTimestamp',
-          streamingSessionId,
-        ) ?? null,
       idealStartTimestamp:
         timestamps.get(
           'streaming_metrics:playback_statistics:idealStartTimestamp',
@@ -448,10 +445,6 @@ export class BasePlayer {
       streamingSessionId,
     }).catch(console.error);
 
-    timestamps.clear(
-      'streaming_metrics:playback_statistics:actualStartTimestamp',
-      streamingSessionId,
-    );
     timestamps.clear(
       'streaming_metrics:playback_statistics:idealStartTimestamp',
       streamingSessionId,
@@ -612,6 +605,37 @@ export class BasePlayer {
     }
 
     return false;
+  }
+
+  /**
+   * This method should be called when playback measurably starts producing
+   * output for a session: the media element's first 'playing' event or the
+   * equivalent player signal. This is stricter than mediaProductStarted,
+   * which runs when playback is requested.
+   *
+   * Only the first call per session takes effect, so later 'playing' events
+   * (resume from pause or stall) don't overwrite the reported value. Sessions
+   * that never reach this point keep actualStartTimestamp as null in
+   * playback_statistics.
+   *
+   * @param streamingSessionId
+   */
+  mediaProductActuallyStarted(streamingSessionId: string | undefined) {
+    if (
+      !streamingSessionId ||
+      streamingSessionStore.hasReportedActualStart(streamingSessionId)
+    ) {
+      return;
+    }
+
+    this.debugLog('mediaProductActuallyStarted');
+
+    streamingSessionStore.setReportedActualStart(streamingSessionId);
+
+    StreamingMetrics.playbackStatistics({
+      actualStartTimestamp: trueTime.now(),
+      streamingSessionId,
+    }).catch(console.error);
   }
 
   /**

--- a/packages/player/src/player/browserPlayer.ts
+++ b/packages/player/src/player/browserPlayer.ts
@@ -128,14 +128,17 @@ export default class BrowserPlayer extends BasePlayer {
       pauseHandler: setNotPlaying,
       playHandler: setPlaying,
       playingHandler: () => {
-        setPlaying();
-
         // 'playing' (unlike 'play') only fires when the element actually
         // starts advancing, so this is the strict "playback actually
         // started" signal. Only the first event per session is reported.
+        // Sample the timestamp before setPlaying(): the playbackState setter
+        // synchronously notifies consumer listeners, whose work should not
+        // be included in the startup time.
         if (this.mediaElement && !this.mediaElement.paused) {
           this.mediaProductActuallyStarted(this.currentStreamingSessionId);
         }
+
+        setPlaying();
       },
       seekedHandler,
       stalledHandler: setStalled,

--- a/packages/player/src/player/browserPlayer.ts
+++ b/packages/player/src/player/browserPlayer.ts
@@ -127,7 +127,16 @@ export default class BrowserPlayer extends BasePlayer {
       errorHandler,
       pauseHandler: setNotPlaying,
       playHandler: setPlaying,
-      playingHandler: setPlaying,
+      playingHandler: () => {
+        setPlaying();
+
+        // 'playing' (unlike 'play') only fires when the element actually
+        // starts advancing, so this is the strict "playback actually
+        // started" signal. Only the first event per session is reported.
+        if (this.mediaElement && !this.mediaElement.paused) {
+          this.mediaProductActuallyStarted(this.currentStreamingSessionId);
+        }
+      },
       seekedHandler,
       stalledHandler: setStalled,
       timeUpdateHandler,

--- a/packages/player/src/player/nativePlayer.ts
+++ b/packages/player/src/player/nativePlayer.ts
@@ -137,11 +137,14 @@ export default class NativePlayer extends BasePlayer {
 
     switch (state) {
       case 'active':
-        this.playbackState = 'PLAYING';
         // 'active' means the native pipeline is actually producing output,
         // so this is the strict "playback actually started" signal. Only
-        // the first call per session is reported.
+        // the first call per session is reported. Sample the timestamp
+        // before the playbackState setter, which synchronously notifies
+        // consumer listeners whose work should not be included in the
+        // startup time.
         this.mediaProductActuallyStarted(this.currentStreamingSessionId);
+        this.playbackState = 'PLAYING';
         break;
       case 'idle':
       case 'seeking':
@@ -283,6 +286,13 @@ export default class NativePlayer extends BasePlayer {
 
     await this.mediaStateChange('active');
 
+    // The 'active' state-change handler attributed the signal to the
+    // outgoing session (currentStreamingSessionId has not switched yet), so
+    // report the actual start for the committed session here -- right after
+    // the awaited signal and before dispatching the transition event, whose
+    // listeners can run arbitrarily long.
+    this.mediaProductActuallyStarted(committedStreamingSessionId);
+
     events.dispatchEvent(
       mediaProductTransitionEvent(mediaProduct, updatedPlaybackContext),
     );
@@ -290,13 +300,6 @@ export default class NativePlayer extends BasePlayer {
     this.currentStreamingSessionId = committedStreamingSessionId;
 
     this.mediaProductStarted(this.currentStreamingSessionId);
-
-    // The 'active' media state was awaited above, before
-    // currentStreamingSessionId switched to the committed session, so the
-    // state-change handler attributed it to the outgoing session. Playback
-    // is known to be active here; report the actual start for the new
-    // session.
-    this.mediaProductActuallyStarted(this.currentStreamingSessionId);
   }
 
   async load(payload: LoadPayload, transition: 'explicit' | 'implicit') {

--- a/packages/player/src/player/nativePlayer.ts
+++ b/packages/player/src/player/nativePlayer.ts
@@ -138,6 +138,10 @@ export default class NativePlayer extends BasePlayer {
     switch (state) {
       case 'active':
         this.playbackState = 'PLAYING';
+        // 'active' means the native pipeline is actually producing output,
+        // so this is the strict "playback actually started" signal. Only
+        // the first call per session is reported.
+        this.mediaProductActuallyStarted(this.currentStreamingSessionId);
         break;
       case 'idle':
       case 'seeking':
@@ -286,6 +290,13 @@ export default class NativePlayer extends BasePlayer {
     this.currentStreamingSessionId = committedStreamingSessionId;
 
     this.mediaProductStarted(this.currentStreamingSessionId);
+
+    // The 'active' media state was awaited above, before
+    // currentStreamingSessionId switched to the committed session, so the
+    // state-change handler attributed it to the outgoing session. Playback
+    // is known to be active here; report the actual start for the new
+    // session.
+    this.mediaProductActuallyStarted(this.currentStreamingSessionId);
   }
 
   async load(payload: LoadPayload, transition: 'explicit' | 'implicit') {

--- a/packages/player/src/player/shakaPlayer.ts
+++ b/packages/player/src/player/shakaPlayer.ts
@@ -567,17 +567,27 @@ export default class ShakaPlayer extends BasePlayer {
       mediaProductTransitionEvent(nextPayload.mediaProduct, playbackContext),
     );
 
-    timestamps.mark(
-      'streaming_metrics:playback_statistics:idealStartTimestamp',
-      nextPayload.streamInfo.streamingSessionId,
-    );
+    // First mark wins: for crossfade/gapless transitions the ideal start was
+    // already marked when the transition was triggered (#startTransition),
+    // and for skipToPreloadedMediaProduct() it was marked by the explicit
+    // load. Only fall back to "now" if no earlier intent timestamp exists.
+    if (
+      timestamps.get(
+        'streaming_metrics:playback_statistics:idealStartTimestamp',
+        nextPayload.streamInfo.streamingSessionId,
+      ) === undefined
+    ) {
+      timestamps.mark(
+        'streaming_metrics:playback_statistics:idealStartTimestamp',
+        nextPayload.streamInfo.streamingSessionId,
+      );
+    }
 
-    // During a crossfade/gapless swap the incoming element has been playing
-    // since the fade started and fires no further 'playing' event when it
-    // becomes the active element, so report the actual start here.
-    // skipToPreloadedMediaProduct() funnels into this method with a paused
-    // element; in that case the 'playing' handler reports the actual start
-    // once play() is called.
+    // Fallback only: for crossfade/gapless the actual start was already
+    // reported at fade start (and mediaProductActuallyStarted is guarded to
+    // first-call-wins). skipToPreloadedMediaProduct() funnels into this
+    // method with a paused element; in that case the 'playing' handler
+    // reports the actual start once play() is called.
     if (!nextMediaElement.paused) {
       this.mediaProductActuallyStarted(
         nextPayload.streamInfo.streamingSessionId,
@@ -1399,6 +1409,15 @@ export default class ShakaPlayer extends BasePlayer {
       nextMediaElement.volume = 0.001;
       await nextMediaElement.play();
       nextMediaElement.volume = 0;
+
+      // The incoming track starts playing (and fading in) right here, at
+      // fade start -- this is its actual start, even though it only becomes
+      // the active element when the fade completes. The outgoing track keeps
+      // reporting until it stops at fade end, so the two sessions overlap in
+      // wall-clock time by design.
+      this.mediaProductActuallyStarted(
+        nextPayload.streamInfo.streamingSessionId,
+      );
     } catch (error) {
       this.debugLog('Error while starting crossfade', error);
       try {
@@ -1509,6 +1528,12 @@ export default class ShakaPlayer extends BasePlayer {
       nextMediaElement.currentTime = 0;
       nextMediaElement.volume = nextTrackTargetVolume;
       await nextMediaElement.play();
+
+      // See #startCrossfadeTransition: the incoming track's actual start is
+      // when it starts playing, not when the swap completes.
+      this.mediaProductActuallyStarted(
+        nextPayload.streamInfo.streamingSessionId,
+      );
     } catch (error) {
       this.debugLog('Error while starting instant transition', error);
       this.#crossfadeInProgress = false;
@@ -1535,6 +1560,14 @@ export default class ShakaPlayer extends BasePlayer {
     }
 
     this.#crossfadeInProgress = true;
+
+    // The incoming track's ideal start is the moment we decide to start the
+    // transition ("start crossfading now"), not when the fade completes.
+    // eventTrackingStreamingStarted picks this up at the transition swap.
+    timestamps.mark(
+      'streaming_metrics:playback_statistics:idealStartTimestamp',
+      this.#preloadedPayload.streamInfo.streamingSessionId,
+    );
 
     if (instant) {
       // Old track already silent (e.g. natural end fired before our timeupdate

--- a/packages/player/src/player/shakaPlayer.ts
+++ b/packages/player/src/player/shakaPlayer.ts
@@ -420,7 +420,20 @@ export default class ShakaPlayer extends BasePlayer {
       errorHandler,
       pauseHandler: setNotPlaying,
       playHandler: setPlaying,
-      playingHandler: setPlaying,
+      playingHandler: (e: Event) => {
+        setPlaying(e);
+
+        // 'playing' (unlike 'play') only fires when the element actually
+        // starts advancing, so this is the strict "playback actually
+        // started" signal. Only the first event per session is reported.
+        if (
+          !shouldIgnoreEvent(e) &&
+          this.mediaElement &&
+          !this.mediaElement.paused
+        ) {
+          this.mediaProductActuallyStarted(this.currentStreamingSessionId);
+        }
+      },
       seekedHandler,
       stalledHandler: setStalled,
       timeUpdateHandler,
@@ -558,6 +571,18 @@ export default class ShakaPlayer extends BasePlayer {
       'streaming_metrics:playback_statistics:idealStartTimestamp',
       nextPayload.streamInfo.streamingSessionId,
     );
+
+    // During a crossfade/gapless swap the incoming element has been playing
+    // since the fade started and fires no further 'playing' event when it
+    // becomes the active element, so report the actual start here.
+    // skipToPreloadedMediaProduct() funnels into this method with a paused
+    // element; in that case the 'playing' handler reports the actual start
+    // once play() is called.
+    if (!nextMediaElement.paused) {
+      this.mediaProductActuallyStarted(
+        nextPayload.streamInfo.streamingSessionId,
+      );
+    }
 
     this.mediaProductStarted(nextPayload.streamInfo.streamingSessionId);
 

--- a/packages/player/src/player/shakaPlayer.ts
+++ b/packages/player/src/player/shakaPlayer.ts
@@ -421,11 +421,12 @@ export default class ShakaPlayer extends BasePlayer {
       pauseHandler: setNotPlaying,
       playHandler: setPlaying,
       playingHandler: (e: Event) => {
-        setPlaying(e);
-
         // 'playing' (unlike 'play') only fires when the element actually
         // starts advancing, so this is the strict "playback actually
         // started" signal. Only the first event per session is reported.
+        // Sample the timestamp before setPlaying(): the playbackState setter
+        // synchronously notifies consumer listeners, whose work should not
+        // be included in the startup time.
         if (
           !shouldIgnoreEvent(e) &&
           this.mediaElement &&
@@ -433,6 +434,8 @@ export default class ShakaPlayer extends BasePlayer {
         ) {
           this.mediaProductActuallyStarted(this.currentStreamingSessionId);
         }
+
+        setPlaying(e);
       },
       seekedHandler,
       stalledHandler: setStalled,


### PR DESCRIPTION
## Why

Follow-up to #696. `actualStartTimestamp` in `playback_statistics` was captured when `play()` was invoked on the SDK — before any audio was actually produced. That means:

- Startup time excluded the initial buffering period (the most interesting part of the metric).
- A session that requested playback but never produced audio (stuck buffering, error mid-startup) still reported an `actualStartTimestamp`.
- Crossfade/gapless transitions stamped the incoming track at fade *end*, so with long crossfades the reported start was off by the whole fade duration.

This PR makes the semantics strict: `idealStartTimestamp` = when playback of the track should start (user intent / transition trigger), `actualStartTimestamp` = when the player measurably starts producing output.

## What

**Strict actual start reporting** — new `BasePlayer.mediaProductActuallyStarted()`, reported from:

- **ShakaPlayer / BrowserPlayer:** the media element's first `playing` event per session (`playing`, unlike `play`, only fires when the element actually starts advancing).
- **NativePlayer:** the `active` media state (plus an explicit call in the preloaded-transition path, where the `active` state is observed before the session id switches).

Only the first call per session takes effect (guarded via `streamingSessionStore`), so resume-from-pause/stall `playing` events don't overwrite the value. `eventTrackingStreamingStarted()` no longer reports `actualStartTimestamp` at all — sessions that never produce audio keep `null` (building on the nullable types from #696).

**Crossfade/gapless: stamp the incoming track at fade start** — if track A crossfades into track B:

- `B.idealStartTimestamp` = when the transition is triggered ("start crossfading now", marked in `#startTransition`).
- `B.actualStartTimestamp` = when B's element starts playing (right after `play()` resolves at fade start).
- A still reports until it stops at fade end, so `A.endTimestamp > B.actualStartTimestamp` — the sessions intentionally overlap in wall-clock time.

The ideal mark in `#completeTransition` is now first-mark-wins, which also stops it from overwriting the load-time intent timestamp in the `skipToPreloadedMediaProduct()` path. The actual-start call there is kept as a guarded fallback.

**Serialized event reducers** — `createReducer` now chains each invocation on the previous one. Reducer calls do an async read-merge-write against the same stored event, so two calls racing in the same tick could drop one call's fields — the same bug class that broke `playback_info_fetch` error reporting in #696, and which this PR would otherwise reintroduce wherever the actual-start write lands next to another `playback_statistics` write (e.g. transition completion).

## Verified

- Added unit tests for reducer merging, including the same-tick race case.
- `pnpm test`: 116 passed, 0 failed (pushkin.test.ts skipped — requires TEST_USER credentials, pre-existing).
- `pnpm run typecheck` and `pnpm run lint` clean.

Note: `play_log` `startTimestamp` semantics are unchanged; this PR only touches `playback_statistics`.