### PR TITLE
Fix Cypress crossfade/gapless failures: keep playback_session in the earliest event batch

### DIFF
--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same event racing in the same tick could previously drop one update's
   fields (the same class of bug as the `playback_info_fetch` error reporting
   fix above).
+- `playback_session` is now enqueued before the session's own
+  `playback_statistics`/`streaming_session_end` events when a session ends.
+  The event sender dispatches at most 10 events per batch, so the enqueue
+  order decides which events make the earliest batch; the consumption-relevant
+  play_log event should not risk being bumped to a later batch by its own
+  session's metrics events.
 
 ## [0.18.4] - 2026-07-27
 

--- a/packages/player/cypress/e2e/play-log/case-crossfade.cy.ts
+++ b/packages/player/cypress/e2e/play-log/case-crossfade.cy.ts
@@ -32,21 +32,28 @@ it('Crossfade Playback Test - 5s crossfade between tracks', () => {
     timeout: SDK_BATCH_INTERVAL + 1000,
   });
 
+  // The event sender dispatches at most 10 events per request, so the two
+  // playback_session events can end up in different batches. Aggregate all
+  // intercepted requests and retry until the second batch (sent one batch
+  // interval later) has arrived if needed.
   // @ts-expect-error - Wrong type from Cypress
-  cy.get('@playerSdkEventsRequest').should(({ request }) => {
-    const formData = new URLSearchParams(request.body);
+  cy.get('@playerSdkEventsRequest.all', { timeout: SDK_BATCH_INTERVAL + 10000 }).should((interceptions) => {
     const events = [];
 
-    for (const [key, value] of formData.entries()) {
-      if (key.includes('MessageBody')) {
-        const event = JSON.parse(decodeURIComponent(value));
-        events.push(event);
+    for (const { request } of interceptions) {
+      const formData = new URLSearchParams(request.body);
+
+      for (const [key, value] of formData.entries()) {
+        if (key.includes('MessageBody')) {
+          const event = JSON.parse(decodeURIComponent(value));
+          events.push(event);
+        }
       }
     }
 
     const playbackSessions = events.filter(({ name }) => name === 'playback_session');
 
-    expect(playbackSessions).to.have.lengthOf(2);
+    expect(playbackSessions, `events seen: ${events.map(({ name }) => name).join(', ')}`).to.have.lengthOf(2);
 
     const firstSession = playbackSessions[0];
     const secondSession = playbackSessions[1];

--- a/packages/player/cypress/e2e/play-log/case-gapless.cy.ts
+++ b/packages/player/cypress/e2e/play-log/case-gapless.cy.ts
@@ -48,25 +48,31 @@ it('Gapless Playback Test - Pink Floyd Album Transition', () => {
     timeout: SDK_BATCH_INTERVAL + 1000,
   });
 
-  // Assert on event batch
+  // Assert on aggregated event batches. The event sender dispatches at most
+  // 10 events per request, so the two playback_session events can end up in
+  // different batches. Aggregate all intercepted requests and retry until
+  // the second batch (sent one batch interval later) has arrived if needed.
   // @ts-expect-error - Wrong type from Cypress
-  cy.get('@playerSdkEventsRequest').should(({ request }) => {
-    // Parse the form data to get all message bodies
-    const formData = new URLSearchParams(request.body);
+  cy.get('@playerSdkEventsRequest.all', { timeout: SDK_BATCH_INTERVAL + 10000 }).should((interceptions) => {
     const events = [];
 
-    // Iterate through all entries to find MessageBody parameters
-    for (const [key, value] of formData.entries()) {
-      if (key.includes('MessageBody')) {
-        const event = JSON.parse(decodeURIComponent(value));
-        events.push(event);
+    for (const { request } of interceptions) {
+      // Parse the form data to get all message bodies
+      const formData = new URLSearchParams(request.body);
+
+      // Iterate through all entries to find MessageBody parameters
+      for (const [key, value] of formData.entries()) {
+        if (key.includes('MessageBody')) {
+          const event = JSON.parse(decodeURIComponent(value));
+          events.push(event);
+        }
       }
     }
 
     const playbackSessions = events.filter(({ name }) => name === 'playback_session');
 
     // Should have two playback sessions (one for each track)
-    expect(playbackSessions).to.have.lengthOf(2);
+    expect(playbackSessions, `events seen: ${events.map(({ name }) => name).join(', ')}`).to.have.lengthOf(2);
 
     const firstSession = playbackSessions[0];
     const secondSession = playbackSessions[1];

--- a/packages/player/src/player/basePlayer.ts
+++ b/packages/player/src/player/basePlayer.ts
@@ -401,25 +401,32 @@ export class BasePlayer {
   ) {
     const endTimestamp = trueTime.now();
 
+    // Enqueue playback_session before the auxiliary streaming metrics: the
+    // event sender caps each dispatch batch at 10 events, so the relative
+    // enqueue order decides which events make the earliest batch. The
+    // play_log event is the consumption-relevant one and must not risk being
+    // bumped to a later batch by its own session's metrics events.
     PlayLog.commit([
       PlayLog.playbackSession({
         endAssetPosition,
         endTimestamp,
         streamingSessionId,
       }),
-    ]).catch(console.error);
-
-    StreamingMetrics.commit([
-      StreamingMetrics.playbackStatistics({
-        endReason: playbackStatisticsEndReason(endReason),
-        endTimestamp,
-        streamingSessionId,
-      }),
-      StreamingMetrics.streamingSessionEnd({
-        streamingSessionId,
-        timestamp: endTimestamp,
-      }),
-    ]).catch(console.error);
+    ])
+      .catch(console.error)
+      .finally(() => {
+        StreamingMetrics.commit([
+          StreamingMetrics.playbackStatistics({
+            endReason: playbackStatisticsEndReason(endReason),
+            endTimestamp,
+            streamingSessionId,
+          }),
+          StreamingMetrics.streamingSessionEnd({
+            streamingSessionId,
+            timestamp: endTimestamp,
+          }),
+        ]).catch(console.error);
+      });
   }
 
   eventTrackingStreamingStarted(streamingSessionId: string) {


### PR DESCRIPTION
## Why

After #697 merged, the Cypress `case-crossfade.cy.ts` and `case-gapless.cy.ts` specs started failing on every open PR (`expected 2 playback_session events, got 1`). The specs never ran on #697 itself because it was stacked on the #696 branch and the Cypress workflow only triggers for PRs targeting `main`.

Root cause: the event sender dispatches at most 10 events per request (SQS batch limit), and the two specs asserted on the **first** intercepted batch only. A crossfade/gapless run produces enough events that the second track's `playback_session` sat exactly at the 10-event batch boundary. The event enqueue-timing changes in #697 (serialized reducers, actual-start reporting) shifted the order so it fell into the second batch — which the specs never looked at.

## What

- `BasePlayer.eventTrackingStreamingEnded` now enqueues `playback_session` before the session's own `playback_statistics`/`streaming_session_end` events, so the consumption-relevant play_log event is never bumped to a later batch by its own session's metrics events.
- The crossfade and gapless specs now aggregate events across **all** intercepted event requests (retrying until a later batch arrives if needed) instead of asserting on the first request only, and include the seen event names in the assertion message for easier diagnosis.

## Verified

- `pnpm --dir packages/player typecheck` and `lint:ci` pass locally.
- Cypress runs in CI on this PR (could not be run locally — requires the CI test-user secret).

Made with [Cursor](https://cursor.com)