### PR TITLE
fix(player): guard maybeSwitchPlayerOnEnd when preloadPlayer is undefined

### DIFF
--- a/packages/player/src/internal/handlers/set-next.ts
+++ b/packages/player/src/internal/handlers/set-next.ts
@@ -179,7 +179,7 @@ async function _setNext(
       playbackInfo,
       streamInfo,
     });
-  } else if (activePlayer && playerState.preloadPlayer) {
+  } else if (activePlayer) {
     await playerState.preloadPlayer.next({
       assetPosition: 0,
       mediaProduct,

--- a/packages/player/src/internal/handlers/set-next.ts
+++ b/packages/player/src/internal/handlers/set-next.ts
@@ -179,7 +179,7 @@ async function _setNext(
       playbackInfo,
       streamInfo,
     });
-  } else if (activePlayer) {
+  } else if (activePlayer && playerState.preloadPlayer) {
     await playerState.preloadPlayer.next({
       assetPosition: 0,
       mediaProduct,

--- a/packages/player/src/player/index.test.ts
+++ b/packages/player/src/player/index.test.ts
@@ -6,6 +6,7 @@ import { mountVideoElements } from './audio-context-store.js';
 
 import {
   getAppropriatePlayer,
+  maybeSwitchPlayerOnEnd,
   resetAllPlayers,
   setPlayerConfig,
 } from './index.js';
@@ -40,6 +41,12 @@ function mockNativePlayer() {
     Player: () => new NativePlayerMock(),
   };
 }
+
+describe('maybeSwitchPlayerOnEnd', () => {
+  it('does not throw when preloadPlayer is undefined', () => {
+    expect(() => maybeSwitchPlayerOnEnd(undefined)).to.not.throw();
+  });
+});
 
 describe('getAppropriatePlayer', () => {
   before(async () => {

--- a/packages/player/src/player/index.ts
+++ b/packages/player/src/player/index.ts
@@ -97,10 +97,7 @@ export function cancelQueuedOnendedHandler() {
 }
 
 export function maybeSwitchPlayerOnEnd(preloadPlayer: Player | undefined) {
-  if (
-    !preloadPlayer ||
-    preloadPlayer.name === playerState.activePlayer?.name
-  ) {
+  if (!preloadPlayer || preloadPlayer.name === playerState.activePlayer?.name) {
     return;
   }
 

--- a/packages/player/src/player/index.ts
+++ b/packages/player/src/player/index.ts
@@ -96,8 +96,11 @@ export function cancelQueuedOnendedHandler() {
   events.removeEventListener('ended', endedHandler);
 }
 
-export function maybeSwitchPlayerOnEnd(preloadPlayer: Player) {
-  if (preloadPlayer.name === playerState.activePlayer?.name) {
+export function maybeSwitchPlayerOnEnd(preloadPlayer: Player | undefined) {
+  if (
+    !preloadPlayer ||
+    preloadPlayer.name === playerState.activePlayer?.name
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- Guard `maybeSwitchPlayerOnEnd` so it no-ops when `preloadPlayer` is undefined, instead of throwing `TypeError: Cannot read properties of undefined (reading 'name')`
- Add a unit test covering the undefined case

This addresses a long-standing handled console error seen in Datadog since May 2026 on playlist views when preload fails or no preload player is set up. Impact is mild (ended listener for player swap may not register for that transition), but the fix removes noisy error telemetry and avoids a gapless-playback edge case.

The guard lives in `maybeSwitchPlayerOnEnd` only — that is where the TypeError occurs. The cross-player `next()` branch in `setNext` does not need the same check: `playerState.preloadPlayer` is assigned earlier in the same function before that branch runs, so it is always defined there in normal flow. A duplicate guard in `setNext` would only help an extremely narrow concurrent-reset race, which is already covered by the `maybeSwitchPlayerOnEnd` guard.

## Test plan
- [x] `pnpm exec wtr src/player/index.test.ts` — 6 passed
- [x] `pnpm run lint:ci` — pass
- [x] CI green