### PR TITLE
ci: switch from pnpm/action-setup to its successor pnpm/setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,9 @@ runs:
   steps:
     # https://pnpm.io/continuous-integration
     - name: Install package manager
-      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
+      with:
+        install: false
     - name: Set up Node.js w/ version from .nvmrc
       uses: actions/setup-node@v7
       with:

--- a/.github/workflows/generate-tidal-api.yml
+++ b/.github/workflows/generate-tidal-api.yml
@@ -32,9 +32,9 @@ jobs:
       SPEC_FILE: bin/tidal-api-oas.json
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          run_install: false
+          install: false
       - uses: actions/setup-node@v7
         with:
           node-version: '24'


### PR DESCRIPTION
## Summary

- `pnpm/action-setup` is [superseded by `pnpm/setup`](https://github.com/pnpm/action-setup#readme) for pnpm v11+ — the new action installs pnpm as a self-contained native executable, while `pnpm/action-setup` remains only for pnpm v10 and older. We are on pnpm 11.21.0 (`packageManager` field), so switch to `pnpm/setup` (pinned to the v2.0.2 digest).
- `actions/setup-node` is kept for the `.nvmrc` node version, npm registry configuration and pnpm store caching. `install: false` is passed since `pnpm/setup` otherwise runs `pnpm install` by default, and both call sites manage installation explicitly.

Supersedes #656 (Renovate digest bump of the old action — the range it bumps over is exactly where upstream added the successor notice).

## Test plan

- [ ] CI on this PR exercises `.github/actions/setup/action.yml` (lint, type check, unit tests, cypress all use it)
- [ ] `generate-tidal-api.yml` path verified on next scheduled API-update run

Made with [Cursor](https://cursor.com)