### PR TITLE
fix(auth): clear the user session before announcing a logout

### DIFF
--- a/packages/api/src/api.test.ts
+++ b/packages/api/src/api.test.ts
@@ -52,6 +52,21 @@ describe('createAPIClient', () => {
     );
   });
 
+  it('sends no request when the provider has no token', async () => {
+    const provider = mockCredentialsProvider();
+    // what a logged out (or anonymous, clientId only) provider hands out
+    provider.getCredentials.mockResolvedValue({
+      clientId: 'test-client',
+      requestedScopes: [],
+    });
+    const client = createAPIClient(provider);
+
+    await expect(client.GET('/albums')).rejects.toThrow(
+      'No access token available',
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('uses custom baseUrl when provided', async () => {
     const provider = mockCredentialsProvider();
     const client = createAPIClient(provider, 'https://custom.api.example/');

--- a/packages/api/src/api.ts
+++ b/packages/api/src/api.ts
@@ -20,10 +20,20 @@ export function createAPIClient(
 ) {
   const authMiddleware: Middleware = {
     async onRequest({ request }) {
-      const credentials = await credentialsProvider.getCredentials();
+      const { token } = await credentialsProvider.getCredentials();
+
+      // A provider without a token has nothing to authenticate with: it is
+      // logged out, or was only ever given a clientId. Sending the request
+      // regardless would put the string "undefined" in the header and come
+      // back as an opaque 401, so fail before the round trip instead.
+      if (!token) {
+        throw new Error(
+          'No access token available from the credentials provider',
+        );
+      }
 
       // Add Authorization header to every request
-      request.headers.set('Authorization', `Bearer ${credentials.token}`);
+      request.headers.set('Authorization', `Bearer ${token}`);
 
       // Set JsonAPI Content-Type header for requests with data
       if (

--- a/packages/auth/src/auth/auth.test.ts
+++ b/packages/auth/src/auth/auth.test.ts
@@ -1,4 +1,5 @@
 import {
+  type Credentials,
   IllegalArgumentError,
   RetryableError,
   TidalError,
@@ -36,6 +37,17 @@ const initConfig = {
   clientUniqueKey: 'CLIENT_UNIQUE_KEY',
   credentialsStorageKey: 'CREDENTIALS_STORAGE_KEY',
   scopes: ['READ', 'WRITE'],
+};
+
+/**
+ * A pristine copy of the module, i.e. one where `init` has never been called.
+ * `logout` keeps the client configuration around, so tests that need a truly
+ * uninitialized module have to re-import it.
+ */
+const uninitializedAuth = async () => {
+  vi.resetModules();
+
+  return import('./auth.js');
 };
 
 const prepareFetchMock = {
@@ -166,11 +178,10 @@ describe.sequential('auth', () => {
 
   describe('initializeLogin', () => {
     it("exits early when `init` hasn't been called before", async () => {
-      // clear local state
-      logout();
+      const auth = await uninitializedAuth();
 
       await expect(
-        initializeLogin({ redirectUri: 'https://foo.com/auth' }),
+        auth.initializeLogin({ redirectUri: 'https://foo.com/auth' }),
       ).rejects.toThrow(authErrorCodeMap.initError);
     });
 
@@ -242,10 +253,9 @@ describe.sequential('auth', () => {
     });
 
     it('exits early when credentials are not present', async () => {
-      // clear local state
-      logout();
+      const auth = await uninitializedAuth();
 
-      await expect(initializeDeviceLogin()).rejects.toThrow(
+      await expect(auth.initializeDeviceLogin()).rejects.toThrow(
         authErrorCodeMap.initError,
       );
     });
@@ -253,10 +263,9 @@ describe.sequential('auth', () => {
 
   describe('finalizeLogin', () => {
     it("exits early when `init` hasn't been called before", async () => {
-      // clear local state
-      logout();
+      const auth = await uninitializedAuth();
 
-      await expect(finalizeLogin('loginQueryResponse')).rejects.toThrow(
+      await expect(auth.finalizeLogin('loginQueryResponse')).rejects.toThrow(
         authErrorCodeMap.initError,
       );
     });
@@ -505,37 +514,101 @@ describe.sequential('auth', () => {
   });
 
   describe('logout', () => {
-    it('logs the user out by deleting credentials', async () => {
+    const loginAUser = async () => {
       vi.mocked(storage.loadCredentials).mockResolvedValue(undefined);
+      // make sure the token we set below isn't expired
+      vi.spyOn(trueTime, 'now').mockReturnValue(fixtures.expiresTimerMock);
 
       await init(initConfig);
+      await setCredentials({
+        accessToken: fixtures.storage.accessToken,
+        refreshToken: 'REFRESH_TOKEN',
+      });
+    };
+
+    it('logs the user out by deleting credentials', async () => {
+      await loginAUser();
 
       logout();
 
       expect(storage.deleteCredentials).toHaveBeenCalledWith(
         'CREDENTIALS_STORAGE_KEY',
       );
-      await expect(initializeLogin({ redirectUri: 'test' })).rejects.toThrow(
-        authErrorCodeMap.initError,
-      );
+      // the user token is gone, only the client configuration is left
+      await expect(getCredentials()).resolves.toEqual({
+        clientId: initConfig.clientId,
+        requestedScopes: initConfig.scopes,
+      });
+    });
+
+    it('keeps the module initialized, so `init` is not needed again', async () => {
+      await loginAUser();
+
+      logout();
+
+      await expect(
+        initializeLogin({ redirectUri: 'https://foo.com/auth' }),
+      ).resolves.toContain('authorize');
+    });
+
+    // Regression test: `logout` used to announce `credentialsUpdated` while the
+    // credentials it was about to delete were still readable. A listener acting
+    // on that event got a live token back, and the follow up read it made based
+    // on it then threw `initError` — the `A0001` that @tidal-music/player
+    // logged on every logout.
+    it('has cleared the credentials by the time the bus is notified', async () => {
+      await loginAUser();
+
+      let listening = true;
+      const reads: Array<Credentials> = [];
+
+      // mirrors what @tidal-music/player does with the event: it reads the
+      // credentials, dispatches `authorized`/`unauthenticated` based on them,
+      // and the handler of that event reads the credentials once more
+      bus(() => {
+        if (!listening) {
+          return;
+        }
+
+        void getCredentials().then(async credentials => {
+          reads.push(credentials, await getCredentials());
+        });
+      });
+
+      logout();
+
+      await vi.waitFor(() => expect(reads).toHaveLength(2));
+      listening = false;
+
+      expect(reads.map(({ token }) => token)).toEqual([undefined, undefined]);
     });
   });
 
   describe('getAccessToken/refreshAccessToken/upgradeToken', () => {
-    it('should exit early if logout was called', async () => {
+    it('falls back to client credentials after a logout', async () => {
       vi.mocked(storage.loadCredentials).mockResolvedValue(undefined);
+      vi.spyOn(trueTime, 'now').mockReturnValue(fixtures.expiresTimerMock);
+      vi.mocked(fetchHandling.handleTokenFetch).mockResolvedValue(
+        new Response(JSON.stringify(fixtures.clientCredentialsJsonResponse)),
+      );
       vi.mocked(fetchHandling.prepareFetch).mockReturnValue(prepareFetchMock);
 
-      await init(initConfig);
+      await init({
+        ...initConfig,
+        clientSecret: 'CLIENT_SECRET',
+      });
 
       logout();
 
       expect(storage.deleteCredentials).toHaveBeenCalledWith(
         'CREDENTIALS_STORAGE_KEY',
       );
-      await expect(getCredentials()).rejects.toThrow(
-        authErrorCodeMap.initError,
-      );
+      // an anonymous token, not the user's one, and not an `initError`
+      expect(await getCredentials()).toEqual({
+        ...fixtures.storageClientCredentials.accessToken,
+        clientUniqueKey: 'CLIENT_UNIQUE_KEY',
+        requestedScopes: ['READ', 'WRITE'],
+      });
     });
 
     it('return accessToken only with basic credentials (no token)', async () => {
@@ -952,11 +1025,10 @@ describe.sequential('auth', () => {
     });
 
     it("throws because module wasn't init", async () => {
-      // clean up state
-      logout();
+      const auth = await uninitializedAuth();
 
       await expect(
-        setCredentials({ accessToken: fixtures.storage.accessToken }),
+        auth.setCredentials({ accessToken: fixtures.storage.accessToken }),
       ).rejects.toEqual(new TidalError(authErrorCodeMap.initError));
     });
   });

--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -379,7 +379,8 @@ export const finalizeDeviceLogin = async () => {
 
 /**
  * Log the user out and clear the user session, both in memory and in the
- * secure storage. Call this method only when the user actively want to log out.
+ * secure storage. Call this method only when the user actively wants to log
+ * out.
  *
  * The client configuration passed to {@link init} is kept, so the module stays
  * initialized and does not need to be initialized again after a logout.

--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -378,17 +378,49 @@ export const finalizeDeviceLogin = async () => {
 };
 
 /**
- * Log the user out and clear all local state and the secure storage.
- * Call this method only when the user actively want to log out.
+ * Log the user out and clear the user session, both in memory and in the
+ * secure storage. Call this method only when the user actively want to log out.
+ *
+ * The client configuration passed to {@link init} is kept, so the module stays
+ * initialized and does not need to be initialized again after a logout.
+ * {@link getCredentials} keeps working and falls back to client credentials.
  */
 export const logout = () => {
-  dispatchEvent({ type: messageTypes.credentialsUpdated });
   if (state.credentials?.credentialsStorageKey) {
     deleteCredentials(state.credentials.credentialsStorageKey);
   }
-  // clear in memory data as well
-  delete state.credentials;
+
+  if (state.credentials) {
+    // Allow list on purpose: everything that came from `init` is kept, and
+    // anything belonging to the logged in user (tokens, PKCE challenge,
+    // redirect uri) is dropped.
+    const {
+      clientId,
+      clientSecret,
+      clientUniqueKey,
+      credentialsStorageKey,
+      scopes,
+      tidalAuthServiceBaseUri,
+      tidalLoginServiceBaseUri,
+    } = state.credentials;
+
+    state.credentials = {
+      clientId,
+      ...(clientSecret && { clientSecret }),
+      clientUniqueKey,
+      credentialsStorageKey,
+      scopes,
+      tidalAuthServiceBaseUri,
+      tidalLoginServiceBaseUri,
+    };
+  }
+
   delete state.limitedDeviceResponse;
+
+  // Announce the change only once the state is cleared, so that a listener
+  // reacting to this event can never read the credentials we just logged out
+  // of.
+  dispatchEvent({ type: messageTypes.credentialsUpdated });
 };
 
 const refreshAccessToken = async () => {

--- a/packages/player/src/internal/credentials-provider-store.test.ts
+++ b/packages/player/src/internal/credentials-provider-store.test.ts
@@ -1,0 +1,70 @@
+import type { CredentialsProvider } from '@tidal-music/common';
+import { expect } from 'chai';
+
+import { credentialsProviderStore, isAuthorizedWithUser } from './index.js';
+
+/**
+ * Shaped like the errors `@tidal-music/auth` rejects with, which carry the code
+ * on `errorCode` rather than encoding it in the class.
+ */
+const authError = (errorCode: string) =>
+  Object.assign(new Error(errorCode), { errorCode });
+
+const rejectingProvider = (error: Error): CredentialsProvider => ({
+  bus: () => {},
+  getCredentials: () => Promise.reject(error),
+});
+
+/**
+ * What `@tidal-music/auth` looks like when it has no credentials to hand out:
+ * it was logged out mid request, or was never initialized.
+ */
+const noCredentialsProvider = () => rejectingProvider(authError('A0001'));
+
+/** A refresh that failed because the client is offline. */
+const networkErrorProvider = () => rejectingProvider(authError('A0002'));
+
+const nextAuthEvent = () =>
+  new Promise<string>(resolve => {
+    credentialsProviderStore.addEventListener(
+      'authorized',
+      () => resolve('authorized'),
+      { once: true },
+    );
+    credentialsProviderStore.addEventListener(
+      'unauthenticated',
+      () => resolve('unauthenticated'),
+      { once: true },
+    );
+  });
+
+describe('credentialsProviderStore', () => {
+  it('dispatches unauthenticated when the provider has no credentials', async () => {
+    const dispatched = nextAuthEvent();
+
+    credentialsProviderStore.credentialsProvider = noCredentialsProvider();
+
+    expect(await dispatched).to.equal('unauthenticated');
+  });
+});
+
+describe('isAuthorizedWithUser', () => {
+  it('is false when the provider has no credentials', async () => {
+    credentialsProviderStore.credentialsProvider = noCredentialsProvider();
+
+    expect(await isAuthorizedWithUser()).to.equal(false);
+  });
+
+  it('rejects instead of reporting an unauthorized user on a network error', async () => {
+    credentialsProviderStore.credentialsProvider = networkErrorProvider();
+
+    let error: unknown;
+    try {
+      await isAuthorizedWithUser();
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).to.have.property('errorCode', 'A0002');
+  });
+});

--- a/packages/player/src/internal/index.ts
+++ b/packages/player/src/internal/index.ts
@@ -25,6 +25,33 @@ class EventSenderStore extends EventTarget {
   }
 }
 
+/**
+ * The code `@tidal-music/auth` rejects with when it has no credentials to hand
+ * out at all: it was never initialized, or the user logged out while the
+ * request was in flight.
+ */
+const AUTH_NO_CREDENTIALS_ERROR_CODE = 'A0001';
+
+/**
+ * Turns "the provider has no credentials for us" into `undefined`, i.e. an
+ * unauthenticated user, and rethrows everything else -- a failed refresh or a
+ * network problem is a real error and must not be reported as a logged out
+ * user.
+ *
+ * Matched on the error code instead of `instanceof TidalError` because the auth
+ * module and the player do not share a copy of that class.
+ */
+const asUnauthenticated = (error: unknown) => {
+  if (
+    (error as { errorCode?: unknown } | null)?.errorCode ===
+    AUTH_NO_CREDENTIALS_ERROR_CODE
+  ) {
+    return undefined;
+  }
+
+  throw error;
+};
+
 class CredentialsProviderStore extends EventTarget {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore - Setter
@@ -62,7 +89,9 @@ class CredentialsProviderStore extends EventTarget {
   }
 
   async dispatchAuthorized(subscriptionId?: number) {
-    const credentials = await this.#credentialsProvider.getCredentials();
+    const credentials = await this.#credentialsProvider
+      .getCredentials()
+      .catch(asUnauthenticated);
 
     // The provider may have been swapped while getCredentials() was in
     // flight. If a subscriptionId was supplied (i.e. caller observed a
@@ -279,10 +308,11 @@ export class PlayerError extends Error {
  */
 export async function isAuthorizedWithUser() {
   if (credentialsProviderStore.credentialsProvider) {
-    const credentials =
-      await credentialsProviderStore.credentialsProvider.getCredentials();
+    const credentials = await credentialsProviderStore.credentialsProvider
+      .getCredentials()
+      .catch(asUnauthenticated);
 
-    return Boolean(credentials.token && credentials.userId);
+    return Boolean(credentials?.token && credentials.userId);
   }
 
   await waitForEvent(credentialsProviderStore, 'authorized');


### PR DESCRIPTION
## The bug

`auth.logout()` dispatched `credentialsUpdated` **before** deleting `state.credentials`. The dispatch is synchronous, so a listener reacting to it read the still-live user token, and its follow-up read then threw `TidalError: A0001` (`initError`) because `logout()` had wiped the state by then.

`@tidal-music/player` does exactly this, so every logout logged an `A0001` in any runtime that survives it:

```
TidalError: A0001
    at getCredentialsInternal
    at Object.getCredentials
    at isAuthorizedWithUser (player/src/internal/index.ts:283)
    at handleAuthorized       (player/src/internal/index.ts:300)
    at <anonymous>            (player/src/internal/index.ts:335)
    at CredentialsProviderStore.dispatchAuthorized (player/src/internal/index.ts:81)
```

Not just noise: the aborted `handleAuthorized()` skips `Config.update({ gatherEvents })` and `Pushkin.refresh()`. Consumers that reload the page on logout (the webclient, the example in #106) never see it.

## Changes

**`auth`** — `logout()` dispatches only once the state is cleared, and keeps the client configuration from `init()` while purging the user tokens. The module stays initialized, so `getCredentials()` falls back to client (or basic) credentials instead of throwing, and the player emits `unauthenticated`. The persisted record is still deleted.

This is what `Auth.md` specifies — *"any locally stored user access token and/or refresh token will be purged"*, with `getCredentials` returning lower-level credentials afterwards rather than raising — and what Android's `LoginRepository.logout()` already does: `eraseTokens()`, then emit.

**`player`** — `dispatchAuthorized` and `isAuthorizedWithUser` treat "the provider has no credentials" as unauthenticated. Other failures (failed refresh, network error) still reject.

**`api`** — the auth middleware sent the literal `Bearer undefined` when the provider had no token; it now fails before the round trip.

## Tests

- **auth** (78 passing): logout leaves the module usable, falls back to client credentials, and a listener reading credentials both on the event and from its follow-up handler sees a logged-out state. All four fail with `A0001` against the previous `logout()`. Tests that used `logout()` as a "reset to uninitialized" helper now re-import via `vi.resetModules()`.
- **player**: new `src/internal/credentials-provider-store.test.ts`. The package's full suite needs a `.env` with a real `TEST_USER`, so only this file was run locally.
- **api** (30 passing): a token-less provider rejects and no request is sent.

`lint:ci` and `typecheck` pass in all three packages.

## Compatibility

Anyone using the `A0001` rejection from `getCredentials()` as a "logged out" signal now gets a token-less credentials object instead. That is the documented contract, but retitle with `fix(auth)!` before squashing if you'd rather it release as breaking. No version bumps or CHANGELOG entries included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
