### PR TITLE
fix(auth): drop token responses that arrive after a logout

### DIFF
--- a/packages/auth/src/auth/auth.test.ts
+++ b/packages/auth/src/auth/auth.test.ts
@@ -694,6 +694,49 @@ describe.sequential('auth', () => {
       expect(accessToken).toEqual(fixtures.storage.accessToken);
     });
 
+    // Regression test: `logout` keeps `state.credentials` around, so a refresh
+    // that was already in flight would happily write its user token back into
+    // memory and into the storage, silently logging the user in again.
+    it('drops a refreshed token that arrives after a logout', async () => {
+      vi.mocked(storage.loadCredentials).mockResolvedValue({
+        ...fixtures.storage,
+        accessToken: {
+          ...fixtures.storage.accessToken,
+          expires: 0,
+        },
+      });
+      vi.spyOn(trueTime, 'now').mockReturnValue(fixtures.expiresTimerMock);
+
+      let respond: (response: Response) => void = () => {};
+      vi.mocked(fetchHandling.handleTokenFetch).mockReturnValue(
+        new Promise<Response>(resolve => {
+          respond = resolve;
+        }),
+      );
+
+      await init(initConfig);
+      vi.mocked(storage.saveCredentialsToStorage).mockClear();
+
+      const refreshing = getCredentials();
+      logout();
+      respond(new Response(JSON.stringify(fixtures.userJsonResponse)));
+
+      await expect(refreshing).rejects.toThrow(authErrorCodeMap.initError);
+      expect(storage.saveCredentialsToStorage).not.toHaveBeenCalled();
+
+      // still logged out: the next call falls back to client credentials
+      // instead of handing out the user token that was in flight
+      vi.mocked(fetchHandling.handleTokenFetch).mockResolvedValue(
+        new Response(JSON.stringify(fixtures.clientCredentialsJsonResponse)),
+      );
+
+      expect(await getCredentials()).toEqual({
+        ...fixtures.storageClientCredentials.accessToken,
+        clientUniqueKey: 'CLIENT_UNIQUE_KEY',
+        requestedScopes: ['READ', 'WRITE'],
+      });
+    });
+
     it('refresh token based on api subStatus', async () => {
       vi.mocked(storage.loadCredentials).mockResolvedValue(fixtures.storage);
       vi.spyOn(trueTime, 'now').mockReturnValue(0); // make sure token isn't expired

--- a/packages/auth/src/auth/auth.test.ts
+++ b/packages/auth/src/auth/auth.test.ts
@@ -737,6 +737,88 @@ describe.sequential('auth', () => {
       });
     });
 
+    // The storage write is asynchronous while `logout` deletes synchronously,
+    // so a logout landing mid-write would otherwise leave the token we just
+    // wrote behind for the next `loadCredentials` to pick up.
+    it('undoes the storage write when a logout lands in the middle of it', async () => {
+      vi.mocked(storage.loadCredentials).mockResolvedValue({
+        ...fixtures.storage,
+        accessToken: {
+          ...fixtures.storage.accessToken,
+          expires: 0,
+        },
+      });
+      vi.spyOn(trueTime, 'now').mockReturnValue(fixtures.expiresTimerMock);
+      vi.mocked(fetchHandling.handleTokenFetch).mockResolvedValue(
+        new Response(JSON.stringify(fixtures.userJsonResponse)),
+      );
+
+      await init(initConfig);
+
+      let finishWrite: () => void = () => {};
+      vi.mocked(storage.saveCredentialsToStorage).mockReturnValue(
+        new Promise<void>(resolve => {
+          finishWrite = () => resolve();
+        }),
+      );
+      // `init` wrote too, and the wait below has to see the refresh's write
+      vi.mocked(storage.saveCredentialsToStorage).mockClear();
+      vi.mocked(storage.deleteCredentials).mockClear();
+
+      const refreshing = getCredentials();
+      await vi.waitFor(() =>
+        expect(storage.saveCredentialsToStorage).toHaveBeenCalled(),
+      );
+
+      logout();
+      finishWrite();
+
+      await expect(refreshing).rejects.toThrow(authErrorCodeMap.initError);
+      // once by `logout` itself, once to undo the write that raced it
+      expect(storage.deleteCredentials).toHaveBeenCalledTimes(2);
+      expect(storage.deleteCredentials).toHaveBeenLastCalledWith(
+        initConfig.credentialsStorageKey,
+      );
+    });
+
+    // A logout removes the key material the write needs, so the storage error
+    // it causes has to reach the caller as the logout it really is.
+    it('reports a write that a logout made fail as a logout', async () => {
+      vi.mocked(storage.loadCredentials).mockResolvedValue({
+        ...fixtures.storage,
+        accessToken: {
+          ...fixtures.storage.accessToken,
+          expires: 0,
+        },
+      });
+      vi.spyOn(trueTime, 'now').mockReturnValue(fixtures.expiresTimerMock);
+      vi.mocked(fetchHandling.handleTokenFetch).mockResolvedValue(
+        new Response(JSON.stringify(fixtures.userJsonResponse)),
+      );
+
+      await init(initConfig);
+
+      let failWrite: () => void = () => {};
+      vi.mocked(storage.saveCredentialsToStorage).mockReturnValue(
+        new Promise<void>((_, reject) => {
+          failWrite = () =>
+            reject(new TidalError(authErrorCodeMap.storageError));
+        }),
+      );
+      // `init` wrote too, and the wait below has to see the refresh's write
+      vi.mocked(storage.saveCredentialsToStorage).mockClear();
+
+      const refreshing = getCredentials();
+      await vi.waitFor(() =>
+        expect(storage.saveCredentialsToStorage).toHaveBeenCalled(),
+      );
+
+      logout();
+      failWrite();
+
+      await expect(refreshing).rejects.toThrow(authErrorCodeMap.initError);
+    });
+
     it('refresh token based on api subStatus', async () => {
       vi.mocked(storage.loadCredentials).mockResolvedValue(fixtures.storage);
       vi.spyOn(trueTime, 'now').mockReturnValue(0); // make sure token isn't expired

--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -727,7 +727,8 @@ const persistToken = async (
     throw new TidalError(authErrorCodeMap.initError);
   }
 
-  const { clientId, clientUniqueKey, scopes } = state.credentials;
+  const { clientId, clientUniqueKey, credentialsStorageKey, scopes } =
+    state.credentials;
 
   const grantedScopes = jsonResponse.scope?.length
     ? jsonResponse.scope?.split(' ')
@@ -746,14 +747,33 @@ const persistToken = async (
     }),
   };
 
-  await persistCredentials({
-    ...state.credentials,
-    accessToken,
-    // there is no refreshToken when renewing the accessToken
-    ...(jsonResponse.refresh_token && {
-      refreshToken: jsonResponse.refresh_token,
-    }),
-  });
+  try {
+    await persistCredentials({
+      ...state.credentials,
+      accessToken,
+      // there is no refreshToken when renewing the accessToken
+      ...(jsonResponse.refresh_token && {
+        refreshToken: jsonResponse.refresh_token,
+      }),
+    });
+  } catch (error) {
+    // A logout removes the key material the write needs, so a storage failure
+    // here is that logout and not a broken storage. Report it as such.
+    if (sessionId !== state.sessionId) {
+      throw new TidalError(authErrorCodeMap.initError);
+    }
+
+    throw error;
+  }
+
+  // The storage write is asynchronous, so a logout can land in the middle of
+  // it and have its (synchronous) delete complete first. That leaves the token
+  // we just wrote behind for the next `loadCredentials` to pick up, so undo it.
+  if (sessionId !== state.sessionId) {
+    deleteCredentials(credentialsStorageKey);
+
+    throw new TidalError(authErrorCodeMap.initError);
+  }
 
   return accessToken;
 };

--- a/packages/auth/src/auth/auth.ts
+++ b/packages/auth/src/auth/auth.ts
@@ -50,9 +50,17 @@ const state: {
   limitedDeviceResponse?: DeviceAuthorizationResponse;
   pending: boolean;
   pendingPromises: Array<(value?: unknown) => void>;
+  /**
+   * Identifies the current session, bumped by {@link logout}. Token requests
+   * remember the id they were started with, which lets {@link persistToken}
+   * drop a response that belongs to a session the user has left in the
+   * meantime.
+   */
+  sessionId: number;
 } = {
   pending: false,
   pendingPromises: [],
+  sessionId: 0,
 };
 
 const TIDAL_LOGIN_SERVICE_BASE_URI = 'https://login.tidal.com/';
@@ -255,6 +263,7 @@ export const finalizeLogin = async (loginResponseQuery: string) => {
     redirectUri,
     scopes,
   } = state.credentials;
+  const { sessionId } = state;
 
   const params = Object.fromEntries(new URLSearchParams(loginResponseQuery));
 
@@ -288,7 +297,7 @@ export const finalizeLogin = async (loginResponseQuery: string) => {
 
   const jsonResponse = (await response.json()) as TokenJSONResponse;
 
-  await persistToken(jsonResponse);
+  await persistToken(jsonResponse, sessionId);
 
   return;
 };
@@ -311,6 +320,7 @@ export const finalizeDeviceLogin = async () => {
 
   const { clientId, clientSecret, clientUniqueKey, scopes } = state.credentials;
   const { deviceCode, expiresIn, interval } = state.limitedDeviceResponse;
+  const { sessionId } = state;
 
   const body = {
     client_id: clientId,
@@ -344,7 +354,7 @@ export const finalizeDeviceLogin = async () => {
 
     if (response.ok) {
       const jsonResponse = (await response.json()) as TokenJSONResponse;
-      await persistToken(jsonResponse);
+      await persistToken(jsonResponse, sessionId);
       return;
     }
 
@@ -359,7 +369,7 @@ export const finalizeDeviceLogin = async () => {
       if (retriedResponse.ok) {
         const jsonResponse =
           (await retriedResponse.json()) as TokenJSONResponse;
-        await persistToken(jsonResponse);
+        await persistToken(jsonResponse, sessionId);
         return;
       }
 
@@ -418,6 +428,11 @@ export const logout = () => {
 
   delete state.limitedDeviceResponse;
 
+  // Invalidate every token request that is still in flight: its response was
+  // fetched for the session we just left, so persisting it would log the user
+  // right back in.
+  state.sessionId += 1;
+
   // Announce the change only once the state is cleared, so that a listener
   // reacting to this event can never read the credentials we just logged out
   // of.
@@ -435,6 +450,7 @@ const refreshAccessToken = async () => {
       refresh_token: state.credentials.refreshToken,
       scope: state.credentials.scopes.join(' '),
     };
+    const { sessionId } = state;
 
     const response = await handleTokenFetch({
       body,
@@ -446,7 +462,7 @@ const refreshAccessToken = async () => {
     }
 
     const jsonResponse = (await response.json()) as TokenJSONResponse;
-    return persistToken(jsonResponse);
+    return persistToken(jsonResponse, sessionId);
   } else {
     return getTokenThroughClientCredentials();
   }
@@ -469,6 +485,7 @@ const upgradeToken = async () => {
       credentials: state.credentials,
       path: 'oauth2/token',
     });
+    const { sessionId } = state;
 
     const response = await exponentialBackoff({
       request: () => globalThis.fetch(url, options),
@@ -484,7 +501,7 @@ const upgradeToken = async () => {
     }
 
     const jsonResponse = (await response.json()) as TokenJSONResponse;
-    return persistToken(jsonResponse);
+    return persistToken(jsonResponse, sessionId);
   } else {
     if (state.credentials) {
       const accessTokenResponse = await getTokenThroughClientCredentials();
@@ -507,6 +524,7 @@ const getTokenThroughClientCredentials = async () => {
       client_secret: state.credentials.clientSecret,
       grant_type: 'client_credentials',
     };
+    const { sessionId } = state;
 
     const response = await handleTokenFetch({
       body,
@@ -518,7 +536,7 @@ const getTokenThroughClientCredentials = async () => {
     }
 
     const jsonResponse = (await response.json()) as TokenJSONResponse;
-    return persistToken(jsonResponse);
+    return persistToken(jsonResponse, sessionId);
   }
 };
 
@@ -694,8 +712,18 @@ const persistCredentials = (updatedCredentials: UserCredentials) => {
   return saveCredentialsToStorage(state.credentials);
 };
 
-const persistToken = async (jsonResponse: TokenJSONResponse) => {
-  if (!state.credentials) {
+/**
+ * Store a freshly fetched token as the current credentials.
+ *
+ * @param sessionId - the value of `state.sessionId` from before the token was
+ * requested. A mismatch means the user logged out while the request was in
+ * flight, in which case the token is dropped instead of persisted.
+ */
+const persistToken = async (
+  jsonResponse: TokenJSONResponse,
+  sessionId: number,
+) => {
+  if (!state.credentials || sessionId !== state.sessionId) {
     throw new TidalError(authErrorCodeMap.initError);
   }
 


### PR DESCRIPTION
Stacked on #718. Review that one first; this PR only adds the last commit.

## Problem

#718 makes `logout()` keep the client configuration so the module stays initialized. That leaves `state.credentials` truthy, so a token request that was **already in flight** when the user logged out still finds somewhere to write its response — and the user session comes back to life, in memory and in the secure storage.

Sequence:

1. `getCredentials()` sees an expired token and starts a refresh.
2. The user hits log out. Credentials are cleared, the bus is notified.
3. The refresh resolves and `persistToken` writes the user token back.

## Fix

`state` gains a `sessionId` that `logout()` bumps. Every token request captures the id it started with, and `persistToken` refuses a response whose id no longer matches. The caller gets the same `initError` it would have seen had the request been made after the logout, and `getCredentials()` falls back to client credentials as expected.

Covers `finalizeLogin`, `finalizeDeviceLogin`, `refreshAccessToken`, `upgradeToken` and `getTokenThroughClientCredentials`.

## Context

Raised by Copilot on #718. The generation-token pattern is not in the cross-platform `Auth.md` spec — Android serializes token work behind `tokenMutex` instead — so it is split out here rather than folded into the spec-conformance fix.

## Testing

`drops a refreshed token that arrives after a logout` holds a refresh open, logs out, then lets it resolve, and asserts the token is rejected, nothing is written to storage, and the next `getCredentials()` returns client credentials. 79 auth tests pass; lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)