### PR TITLE
chore(release): auth 1.6.2, player 0.20.1

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sync to new API definitions (version: 1.10.104)
 
+### Fixed
+
+- The auth middleware no longer sends `Authorization: Bearer undefined` when the
+  credentials provider has no token (logged out, or anonymous with only a
+  `clientId`). The request now fails before the round trip rather than coming
+  back as an opaque 401
+  ([#718](https://github.com/tidal-music/tidal-sdk-web/pull/718)).
+
 ## [0.43.0] - 2026-08-15
 
 ### Changed

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-08-20
+
+### Fixed
+
+- `logout()` now announces `credentialsUpdated` only once the session state has
+  been cleared, so a listener reacting to that event can no longer read the
+  credentials being logged out of. It also keeps the client configuration from
+  `init()` and drops only what belongs to the logged-in user, so
+  `getCredentials()` falls back to client credentials instead of throwing
+  `initError`, and callers no longer have to re-run `init()` after a logout
+  ([#718](https://github.com/tidal-music/tidal-sdk-web/pull/718)).
+- A token request that was already in flight when `logout()` ran can no longer
+  bring the session back to life, in memory or in secure storage. The state
+  carries a `sessionId` that `logout()` bumps, and a token response whose id no
+  longer matches is rejected with `initError`; a storage write that a logout
+  races is undone rather than left behind for the next `loadCredentials()`
+  ([#719](https://github.com/tidal-music/tidal-sdk-web/pull/719)).
+
 ## [1.6.1] - 2026-05-13
 
 ### Fixed

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -21,7 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carries a `sessionId` that `logout()` bumps, and a token response whose id no
   longer matches is rejected with `initError`; a storage write that a logout
   races is undone rather than left behind for the next `loadCredentials()`
-  ([#719](https://github.com/tidal-music/tidal-sdk-web/pull/719)).
+  ([#719](https://github.com/tidal-music/tidal-sdk-web/pull/719)). Note that the
+  undo is only synchronous on the default encrypted-`localStorage` backend. A
+  custom `StorageAdapter`'s `remove()` is dispatched without being awaited, so
+  with one installed the removal can still be outrun by an immediate `init()`,
+  or interrupted by a shutdown.
 
 ## [1.6.1] - 2026-05-13
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/auth",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "type": "module",
   "files": [
     "dist"

--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -11,10 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - An auth module that has been logged out, or was never initialized, is now
   treated as an unauthenticated user instead of surfacing a `console.error`'d
-  `A0001`. `handleAuthorized` no longer aborts halfway, so
-  `Config.update({ gatherEvents })` and `Pushkin.refresh()` still run. Only the
-  "no credentials at all" case is swallowed — a failed refresh or a network
-  problem still rejects
+  `A0001`. The credentials store dispatches `unauthenticated` rather than
+  letting the rejection escape, so event gathering is configured for a logged
+  out user instead of the handler aborting part way through. Only the "no
+  credentials at all" case is swallowed — a failed refresh or a network problem
+  still rejects
   ([#718](https://github.com/tidal-music/tidal-sdk-web/pull/718)).
 
 ## [0.20.0] - 2026-08-17

--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - 2026-08-20
+
+### Fixed
+
+- An auth module that has been logged out, or was never initialized, is now
+  treated as an unauthenticated user instead of surfacing a `console.error`'d
+  `A0001`. `handleAuthorized` no longer aborts halfway, so
+  `Config.update({ gatherEvents })` and `Pushkin.refresh()` still run. Only the
+  "no credentials at all" case is swallowed — a failed refresh or a network
+  problem still rejects
+  ([#718](https://github.com/tidal-music/tidal-sdk-web/pull/718)).
+
 ## [0.20.0] - 2026-08-17
 
 ### Changed

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tidal-music/player",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Player logic for TIDAL",
   "type": "module",
   "exports": {


### PR DESCRIPTION
The logout fixes in #718 and #719 landed on `main` without a version bump, so the release pipeline never fired and they never reached npm. `@tidal-music/auth` on npm is still 1.6.1 from 2026-05-13, and `@tidal-music/player` 0.20.0 predates #718. This bumps both so the fixes actually ship.

## Releases

| Package | From | To | Ships |
| --- | --- | --- | --- |
| `@tidal-music/auth` | 1.6.1 | 1.6.2 | #718 logout ordering, #719 session resurrection |
| `@tidal-music/player` | 0.20.0 | 0.20.1 | #718 credential-less provider reads as unauthenticated |

## Also in here

`packages/api/CHANGELOG.md` gains a `Fixed` bullet under the pending 0.44.0 entry for the auth-middleware fix from #718. That fix is already on `main`, so api 0.44.0 ships it either way — the entry only said "Sync to new API definitions". No api version change, since 0.44.0 has not been published yet.

## Verified locally

- `auth`: `tsc` clean, 81/81 tests pass, `lint:ci` clean, builds.
- `player`: `tsc` clean, `lint:ci` clean, builds. Its suite runs under web-test-runner, so I left that to CI.

## Note on publishing

`release-to-npm.yml` runs `pnpm publish --recursive`, so publishing any one of the resulting draft releases publishes every package whose version is not yet on npm — here api 0.44.0, auth 1.6.2 and player 0.20.1 together. `@tidal-music/template` is `private`, so it stays unpublished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)